### PR TITLE
Clone resources before processing

### DIFF
--- a/integration_tests/main_test.go
+++ b/integration_tests/main_test.go
@@ -178,6 +178,7 @@ func TestWorkflow(t *testing.T) {
 		Do().
 		Into(&tmplRes))
 	require.Equal(t, smith.READY, tmplRes.Status.State, "%#v", tmplRes)
+	require.Equal(t, tmpl.Spec, tmplRes.Spec, "%#v", tmplRes)
 }
 
 func tmplResources(t *testing.T) []smith.Resource {

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -60,7 +60,7 @@ func (a *App) Run(ctx context.Context) error {
 
 	// 3. Processor
 
-	tp := processor.New(ctx, tmplClient, clients, rc)
+	tp := processor.New(ctx, tmplClient, clients, rc, tmplScheme)
 	defer tp.Join() // await termination
 	defer cancel()  // cancel ctx to signal done to processor (and everything else)
 

--- a/pkg/processor/processor.go
+++ b/pkg/processor/processor.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/cenk/backoff"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/rest"
 )
@@ -30,6 +31,7 @@ type TemplateProcessor struct {
 	templateClient *rest.RESTClient
 	clients        dynamic.ClientPool
 	rc             ReadyChecker
+	scheme         *runtime.Scheme
 	wg             sync.WaitGroup // tracks number of Goroutines running rebuildLoop()
 
 	lock    sync.RWMutex // protects fields below
@@ -38,13 +40,14 @@ type TemplateProcessor struct {
 
 // New creates a new template processor.
 // Instances are safe for concurrent use.
-func New(ctx context.Context, templateClient *rest.RESTClient, clients dynamic.ClientPool, rc ReadyChecker) *TemplateProcessor {
+func New(ctx context.Context, templateClient *rest.RESTClient, clients dynamic.ClientPool, rc ReadyChecker, scheme *runtime.Scheme) *TemplateProcessor {
 	return &TemplateProcessor{
 		ctx:            ctx,
 		backoff:        exponentialBackOff,
 		templateClient: templateClient,
 		clients:        clients,
 		rc:             rc,
+		scheme:         scheme,
 		workers:        make(map[workerRef]*worker),
 	}
 }

--- a/pkg/processor/worker.go
+++ b/pkg/processor/worker.go
@@ -66,7 +66,11 @@ func (wrk *worker) rebuild(tmpl *smith.Template) error {
 		if wrk.checkNeedsRebuild() {
 			return nil
 		}
-		isReady, err := wrk.checkResource(tmpl, &res)
+		resClone, err := wrk.tp.scheme.DeepCopy(&res)
+		if err != nil {
+			return err
+		}
+		isReady, err := wrk.checkResource(tmpl, resClone.(*smith.Resource))
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
This prevents mutations of the original object