### PR TITLE
Deep copy objects returned from Store

### DIFF
--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -60,7 +60,7 @@ func (a *App) Run(ctx context.Context) error {
 	secretInf := informerFactory.Core().V1().Secrets().Informer()
 	bundleInf := bundleInformer(bundleClient)
 
-	store := NewStore()
+	store := NewStore(bundleScheme)
 	store.AddInformer(tprGVK, tprInf)
 	store.AddInformer(schema.GroupVersionKind{Group: "extensions", Version: "v1beta1", Kind: "Deployment"}, deploymentInf)
 	store.AddInformer(schema.GroupVersionKind{Group: "extensions", Version: "v1beta1", Kind: "Ingress"}, ingressInf)
@@ -119,8 +119,7 @@ func (a *App) Run(ctx context.Context) error {
 	}
 
 	sl := bundleStore{
-		store:  store,
-		scheme: bundleScheme,
+		store: store,
 	}
 	reh := &resourceEventHandler{
 		processor:   bp,

--- a/pkg/app/bundle_store.go
+++ b/pkg/app/bundle_store.go
@@ -2,13 +2,10 @@ package app
 
 import (
 	"github.com/atlassian/smith"
-
-	"k8s.io/apimachinery/pkg/runtime"
 )
 
 type bundleStore struct {
-	store  smith.ByNameStore
-	scheme *runtime.Scheme
+	store smith.ByNameStore
 }
 
 func (s *bundleStore) Get(namespace, bundleName string) (*smith.Bundle, error) {
@@ -16,10 +13,5 @@ func (s *bundleStore) Get(namespace, bundleName string) (*smith.Bundle, error) {
 	if err != nil || !exists {
 		return nil, err
 	}
-	out, err := s.scheme.DeepCopy(bundle)
-	if err != nil {
-		return nil, err
-	}
-
-	return out.(*smith.Bundle), nil
+	return bundle.(*smith.Bundle), nil
 }


### PR DESCRIPTION
Must prevent mutations to objects returned by Informer index.