### PR TITLE
Rework processor-worker interaction

### DIFF
--- a/pkg/app/bundle_event_handler.go
+++ b/pkg/app/bundle_event_handler.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"context"
 	"log"
 
 	"github.com/atlassian/smith"
@@ -9,6 +10,7 @@ import (
 )
 
 type bundleEventHandler struct {
+	ctx       context.Context
 	processor Processor
 	scheme    *runtime.Scheme
 }
@@ -39,5 +41,7 @@ func (h *bundleEventHandler) handle(obj interface{}) {
 
 	out := o.(*smith.Bundle)
 	log.Printf("[BEH] Rebuilding %s/%s bundle because it was added/updated", out.Metadata.Namespace, out.Metadata.Name)
-	h.processor.Rebuild(out)
+	if err = h.processor.Rebuild(h.ctx, out); err != nil && err != context.Canceled && err != context.DeadlineExceeded {
+		log.Printf("[BEH] Error rebuilding bundle %s/%s: %v", out.Metadata.Namespace, out.Metadata.Name, err)
+	}
 }

--- a/pkg/app/types.go
+++ b/pkg/app/types.go
@@ -1,6 +1,8 @@
 package app
 
 import (
+	"context"
+
 	"github.com/atlassian/smith"
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -16,5 +18,5 @@ var bundleGVK = schema.GroupVersionKind{
 }
 
 type Processor interface {
-	Rebuild(*smith.Bundle)
+	Rebuild(context.Context, *smith.Bundle) error
 }

--- a/pkg/processor/types.go
+++ b/pkg/processor/types.go
@@ -1,0 +1,30 @@
+package processor
+
+import (
+	"github.com/atlassian/smith"
+
+	"github.com/cenk/backoff"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+type ReadyChecker interface {
+	IsReady(*unstructured.Unstructured) (isReady, retriableError bool, e error)
+}
+
+type BackOffFactory func() backoff.BackOff
+
+type bundleRef struct {
+	namespace  string
+	bundleName string
+}
+
+type workRequest struct {
+	bundleRef
+	work chan<- *smith.Bundle
+}
+
+type notifyRequest struct {
+	bundleRef
+	bundle *smith.Bundle
+	notify chan<- struct{}
+}


### PR DESCRIPTION
1. Interrupt backoff sleep if bundle needs to be rebuilt
2. Use channels instead of locks
3. Worker does not depend on processor directly
4. Fix datarace on waitgroup

```
==================
WARNING: DATA RACE
Write at 0x00c4202dbc54 by goroutine 75:
  internal/race.Write()
      /usr/local/Cellar/go/1.8/libexec/src/internal/race/race.go:41 +0x38
  sync.(*WaitGroup).Wait()
      /usr/local/Cellar/go/1.8/libexec/src/sync/waitgroup.go:129 +0x14b
  github.com/atlassian/smith/pkg/processor.(*BundleProcessor).Join()
      /Users/ash2k/gopath/src/github.com/atlassian/smith/pkg/processor/processor.go:56 +0x3e
  github.com/atlassian/smith/pkg/app.(*App).Run()
      /Users/ash2k/gopath/src/github.com/atlassian/smith/pkg/app/app.go:107 +0xe4d
  github.com/atlassian/smith/integration_tests.TestTprAttribute.func2()
      /Users/ash2k/gopath/src/github.com/atlassian/smith/integration_tests/tpr_attribute_test.go:99 +0xc2

Previous read at 0x00c4202dbc54 by goroutine 110:
  internal/race.Read()
      /usr/local/Cellar/go/1.8/libexec/src/internal/race/race.go:37 +0x38
  sync.(*WaitGroup).Add()
      /usr/local/Cellar/go/1.8/libexec/src/sync/waitgroup.go:71 +0x26b
  github.com/atlassian/smith/pkg/processor.(*BundleProcessor).Rebuild()
      /Users/ash2k/gopath/src/github.com/atlassian/smith/pkg/processor/processor.go:76 +0x3e0
  github.com/atlassian/smith/pkg/app.(*resourceEventHandler).rebuildByName()
      /Users/ash2k/gopath/src/github.com/atlassian/smith/pkg/app/resource_event_handler.go:52 +0x4b3
  github.com/atlassian/smith/pkg/app.(*resourceEventHandler).OnUpdate()
      /Users/ash2k/gopath/src/github.com/atlassian/smith/pkg/app/resource_event_handler.go:33 +0x16f
  github.com/atlassian/smith/vendor/k8s.io/client-go/tools/cache.(*processorListener).run()
      /Users/ash2k/gopath/src/github.com/atlassian/smith/vendor/k8s.io/client-go/tools/cache/shared_informer.go:545 +0x353

Goroutine 75 (running) created at:
  github.com/atlassian/smith/integration_tests.TestTprAttribute()
      /Users/ash2k/gopath/src/github.com/atlassian/smith/integration_tests/tpr_attribute_test.go:102 +0x658
  testing.tRunner()
      /usr/local/Cellar/go/1.8/libexec/src/testing/testing.go:657 +0x107

Goroutine 110 (finished) created at:
  github.com/atlassian/smith/vendor/k8s.io/client-go/tools/cache.(*sharedProcessor).run()
      /Users/ash2k/gopath/src/github.com/atlassian/smith/vendor/k8s.io/client-go/tools/cache/shared_informer.go:402 +0xe3
  github.com/atlassian/smith/vendor/k8s.io/client-go/tools/cache.(*sharedIndexInformer).Run()
      /Users/ash2k/gopath/src/github.com/atlassian/smith/vendor/k8s.io/client-go/tools/cache/shared_informer.go:212 +0x618
==================
```