### PR TITLE
Add support for ignored fields cleanup

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -14,6 +14,7 @@ import (
 	"github.com/atlassian/smith/pkg/resources"
 	"github.com/atlassian/smith/pkg/store"
 
+	"github.com/atlassian/smith/pkg/cleanup"
 	"github.com/ash2k/stager"
 	sc_v1a1 "github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog/v1alpha1"
 	scClientset "github.com/kubernetes-incubator/service-catalog/pkg/client/clientset_generated/clientset"
@@ -85,11 +86,18 @@ func (a *App) Run(ctx context.Context) error {
 	}
 
 	// 2. Ready Checker
-	types := []map[schema.GroupKind]readychecker.IsObjectReady{readychecker.MainKnownTypes}
+	readyTypes := []map[schema.GroupKind]readychecker.IsObjectReady{readychecker.MainKnownTypes}
 	if a.ServiceCatalogConfig != nil {
-		types = append(types, readychecker.ServiceCatalogKnownTypes)
+		readyTypes = append(readyTypes, readychecker.ServiceCatalogKnownTypes)
 	}
-	rc := readychecker.New(&store.Tpr{Store: multiStore}, types...)
+	rc := readychecker.New(&store.Tpr{store: multiStore}, readyTypes...)
+
+	// 3. Object cleanup
+	cleanupTypes := []map[schema.GroupKind]cleanup.Cleanup{cleanup.MainKnownTypes}
+	if a.ServiceCatalogConfig != nil {
+		cleanupTypes = append(cleanupTypes, cleanup.ServiceCatalogKnownTypes)
+	}
+	oc := cleanup.New(cleanupTypes...)
 
 	// 3. Ensure ThirdPartyResource Bundle exists
 	err = retryUntilSuccessOrDone(ctx, func() error {
@@ -111,6 +119,7 @@ func (a *App) Run(ctx context.Context) error {
 
 	queue := workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "bundle")
 	cntrlr := controller.New(bundleInf, tprInf, bundleClient, bs, sc, rc, scheme, multiStore, queue, a.Workers, a.ResyncPeriod, resourceInfs)
+	cntrlr := controller.New(bundleInf, tprInf, bundleClient, bs, sc, rc, scheme, rawStore, queue, a.Workers, oc, a.ResyncPeriod, resourceInfs)
 
 	// Add all to Multi store
 	for gvk, inf := range resourceInfs {

--- a/app/app.go
+++ b/app/app.go
@@ -14,8 +14,8 @@ import (
 	"github.com/atlassian/smith/pkg/resources"
 	"github.com/atlassian/smith/pkg/store"
 
-	"github.com/atlassian/smith/pkg/cleanup"
 	"github.com/ash2k/stager"
+	"github.com/atlassian/smith/pkg/cleanup"
 	sc_v1a1 "github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog/v1alpha1"
 	scClientset "github.com/kubernetes-incubator/service-catalog/pkg/client/clientset_generated/clientset"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -90,7 +90,7 @@ func (a *App) Run(ctx context.Context) error {
 	if a.ServiceCatalogConfig != nil {
 		readyTypes = append(readyTypes, readychecker.ServiceCatalogKnownTypes)
 	}
-	rc := readychecker.New(&store.Tpr{store: multiStore}, readyTypes...)
+	rc := readychecker.New(&store.Tpr{Store: multiStore}, readyTypes...)
 
 	// 3. Object cleanup
 	cleanupTypes := []map[schema.GroupKind]cleanup.SpecCleanup{cleanup.MainKnownTypes}
@@ -118,8 +118,7 @@ func (a *App) Run(ctx context.Context) error {
 	}
 
 	queue := workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "bundle")
-	cntrlr := controller.New(bundleInf, tprInf, bundleClient, bs, sc, rc, scheme, multiStore, queue, a.Workers, a.ResyncPeriod, resourceInfs)
-	cntrlr := controller.New(bundleInf, tprInf, bundleClient, bs, sc, rc, scheme, rawStore, queue, a.Workers, oc, a.ResyncPeriod, resourceInfs)
+	cntrlr := controller.New(bundleInf, tprInf, bundleClient, bs, sc, rc, scheme, multiStore, queue, a.Workers, oc, a.ResyncPeriod, resourceInfs)
 
 	// Add all to Multi store
 	for gvk, inf := range resourceInfs {

--- a/app/app.go
+++ b/app/app.go
@@ -93,7 +93,7 @@ func (a *App) Run(ctx context.Context) error {
 	rc := readychecker.New(&store.Tpr{store: multiStore}, readyTypes...)
 
 	// 3. Object cleanup
-	cleanupTypes := []map[schema.GroupKind]cleanup.Cleanup{cleanup.MainKnownTypes}
+	cleanupTypes := []map[schema.GroupKind]cleanup.SpecCleanup{cleanup.MainKnownTypes}
 	if a.ServiceCatalogConfig != nil {
 		cleanupTypes = append(cleanupTypes, cleanup.ServiceCatalogKnownTypes)
 	}

--- a/examples/service_catalog/application.yaml
+++ b/examples/service_catalog/application.yaml
@@ -12,7 +12,6 @@ spec:
       metadata:
         name: instance1
       spec:
-        externalID: 786abffa-ed42-4c70-a06f-3836fe3d641c
         serviceClassName: user-provided-service
         planName: default
         parameters:

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
 hash: 0692fa7cb18d68b7938d3ebf645c7947ef1180206b5faaf610841257d536dc2e
-updated: 2017-06-22T22:49:32.812513388+10:00
+updated: 2017-06-26T14:22:55.551432599+10:00
 imports:
 - name: github.com/ash2k/stager
   version: 6e9c7b0eacd465286fac042bfb29a170aa8c2c3f
@@ -43,7 +43,7 @@ imports:
 - name: github.com/juju/ratelimit
   version: 77ed1c8a01217656d2080ad51981f6e99adaa177
 - name: github.com/kubernetes-incubator/service-catalog
-  version: 77943ba2f09cf52a2c24c60f82183f5ce68e72fe
+  version: 9ed6812383d2658fe23d665bb3ff7b068795c499
   subpackages:
   - pkg/apis/servicecatalog
   - pkg/apis/servicecatalog/v1alpha1

--- a/pkg/cleanup/built_in_types.go
+++ b/pkg/cleanup/built_in_types.go
@@ -1,0 +1,72 @@
+package cleanup
+
+import (
+	"fmt"
+
+	sc_v1a1 "github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog/v1alpha1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	unstructured_conversion "k8s.io/apimachinery/pkg/conversion/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	apps_v1b1 "k8s.io/client-go/pkg/apis/apps/v1beta1"
+	ext_v1b1 "k8s.io/client-go/pkg/apis/extensions/v1beta1"
+)
+
+var converter = unstructured_conversion.NewConverter(false)
+
+var MainKnownTypes = map[schema.GroupKind]Cleanup{
+	{Group: apps_v1b1.GroupName, Kind: "Deployment"}: deploymentAppsCleanup,
+	{Group: ext_v1b1.GroupName, Kind: "Deployment"}:  deploymentExtCleanup,
+}
+
+var ServiceCatalogKnownTypes = map[schema.GroupKind]Cleanup{
+	{Group: sc_v1a1.GroupName, Kind: "Binding"}:  scBindingCleanup,
+	{Group: sc_v1a1.GroupName, Kind: "Instance"}: scInstanceCleanup,
+}
+
+func deploymentExtCleanup(obj *unstructured.Unstructured) (err error) {
+	var deployment ext_v1b1.Deployment
+	if err := converter.FromUnstructured(obj.Object, &deployment); err != nil {
+		return err
+	}
+
+	// TODO: implement cleanup
+	fmt.Print("deploymentExtCleanup\n")
+
+	return nil
+}
+
+func deploymentAppsCleanup(obj *unstructured.Unstructured) (err error) {
+	var deployment apps_v1b1.Deployment
+	if err := converter.FromUnstructured(obj.Object, &deployment); err != nil {
+		return err
+	}
+
+	// TODO: implement cleanup
+	fmt.Print("deploymentAppsCleanup\n")
+
+	return nil
+}
+
+func scBindingCleanup(obj *unstructured.Unstructured) (err error) {
+	var binding sc_v1a1.Binding
+	if err := converter.FromUnstructured(obj.Object, &binding); err != nil {
+		return err
+	}
+
+	fmt.Printf("scBindingCleanup: binding.Spec.ExternalID=%s\n", binding.Spec.ExternalID)
+	binding.Spec.ExternalID = ""
+
+	return nil
+}
+
+func scInstanceCleanup(obj *unstructured.Unstructured) (err error) {
+	var instance sc_v1a1.Instance
+	if err := converter.FromUnstructured(obj.Object, &instance); err != nil {
+		return err
+	}
+
+	fmt.Printf("scBindingCleanup: binding.Spec.ExternalID=%s\n", instance.Spec.ExternalID)
+	instance.Spec.ExternalID = ""
+
+	return nil
+}

--- a/pkg/cleanup/object_cleanup.go
+++ b/pkg/cleanup/object_cleanup.go
@@ -8,12 +8,12 @@ import (
 )
 
 type ObjectCleaner interface {
-	Cleanup(obj *unstructured.Unstructured) error
+	Cleanup(obj *unstructured.Unstructured) (updatedObj *unstructured.Unstructured, err error)
 }
 
 // Cleanup cleans the fields of the object which should be ignored.
 // Each function is responsible for handling different versions of objects itself.
-type Cleanup func(*unstructured.Unstructured) (err error)
+type Cleanup func(obj *unstructured.Unstructured) (updatedObj *unstructured.Unstructured, err error)
 
 type ObjectCleanerImpl struct {
 	KnownTypes map[schema.GroupKind]Cleanup
@@ -34,18 +34,18 @@ func New(kts ...map[schema.GroupKind]Cleanup) ObjectCleaner {
 	}
 }
 
-func (oc *ObjectCleanerImpl) Cleanup(obj *unstructured.Unstructured) error {
+func (oc *ObjectCleanerImpl) Cleanup(obj *unstructured.Unstructured) (updatedObj *unstructured.Unstructured, err error) {
 	gvk := obj.GroupVersionKind()
 	gk := gvk.GroupKind()
 
 	if gk.Kind == "" || gvk.Version == "" { // Group can be empty e.g. built-in objects like ConfigMap
-		return fmt.Errorf("object %q has empty kind/version: %v", obj.GetName(), gvk)
+		return nil, fmt.Errorf("object %q has empty kind/version: %v", obj.GetName(), gvk)
 	}
 
 	// Check if it is a known built-in resource
-	if removeIgnoredFields, ok := oc.KnownTypes[gk]; ok {
-		return removeIgnoredFields(obj)
+	if objCleanup, ok := oc.KnownTypes[gk]; ok {
+		return objCleanup(obj)
 	}
 
-	return nil
+	return obj, nil
 }

--- a/pkg/cleanup/object_cleanup.go
+++ b/pkg/cleanup/object_cleanup.go
@@ -7,20 +7,20 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
-type ObjectCleaner interface {
-	Cleanup(obj *unstructured.Unstructured) (updatedObj *unstructured.Unstructured, err error)
+type SpecCleaner interface {
+	Cleanup(spec *unstructured.Unstructured, actual *unstructured.Unstructured) (updatedSpec *unstructured.Unstructured, err error)
 }
 
-// Cleanup cleans the fields of the object which should be ignored.
+// SpecCleanup cleans the fields of the object which should be ignored.
 // Each function is responsible for handling different versions of objects itself.
-type Cleanup func(obj *unstructured.Unstructured) (updatedObj *unstructured.Unstructured, err error)
+type SpecCleanup func(spec *unstructured.Unstructured, actual *unstructured.Unstructured) (updatedSpec *unstructured.Unstructured, err error)
 
-type ObjectCleanerImpl struct {
-	KnownTypes map[schema.GroupKind]Cleanup
+type SpecCleanerImpl struct {
+	KnownTypes map[schema.GroupKind]SpecCleanup
 }
 
-func New(kts ...map[schema.GroupKind]Cleanup) ObjectCleaner {
-	kt := make(map[schema.GroupKind]Cleanup)
+func New(kts ...map[schema.GroupKind]SpecCleanup) SpecCleaner {
+	kt := make(map[schema.GroupKind]SpecCleanup)
 	for _, knownTypes := range kts {
 		for knownGK, f := range knownTypes {
 			if kt[knownGK] != nil {
@@ -29,23 +29,23 @@ func New(kts ...map[schema.GroupKind]Cleanup) ObjectCleaner {
 			kt[knownGK] = f
 		}
 	}
-	return &ObjectCleanerImpl{
+	return &SpecCleanerImpl{
 		KnownTypes: kt,
 	}
 }
 
-func (oc *ObjectCleanerImpl) Cleanup(obj *unstructured.Unstructured) (updatedObj *unstructured.Unstructured, err error) {
-	gvk := obj.GroupVersionKind()
+func (oc *SpecCleanerImpl) Cleanup(spec *unstructured.Unstructured, actual *unstructured.Unstructured) (updatedSpec *unstructured.Unstructured, err error) {
+	gvk := spec.GroupVersionKind()
 	gk := gvk.GroupKind()
 
 	if gk.Kind == "" || gvk.Version == "" { // Group can be empty e.g. built-in objects like ConfigMap
-		return nil, fmt.Errorf("object %q has empty kind/version: %v", obj.GetName(), gvk)
+		return nil, fmt.Errorf("object %q has empty kind/version: %v", spec.GetName(), gvk)
 	}
 
 	// Check if it is a known built-in resource
 	if objCleanup, ok := oc.KnownTypes[gk]; ok {
-		return objCleanup(obj)
+		return objCleanup(spec, actual)
 	}
 
-	return obj, nil
+	return spec, nil
 }

--- a/pkg/cleanup/object_cleanup.go
+++ b/pkg/cleanup/object_cleanup.go
@@ -1,0 +1,51 @@
+package cleanup
+
+import (
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+type ObjectCleaner interface {
+	Cleanup(obj *unstructured.Unstructured) error
+}
+
+// Cleanup cleans the fields of the object which should be ignored.
+// Each function is responsible for handling different versions of objects itself.
+type Cleanup func(*unstructured.Unstructured) (err error)
+
+type ObjectCleanerImpl struct {
+	KnownTypes map[schema.GroupKind]Cleanup
+}
+
+func New(kts ...map[schema.GroupKind]Cleanup) ObjectCleaner {
+	kt := make(map[schema.GroupKind]Cleanup)
+	for _, knownTypes := range kts {
+		for knownGK, f := range knownTypes {
+			if kt[knownGK] != nil {
+				panic(fmt.Errorf("GK specified more than once: %s", knownGK))
+			}
+			kt[knownGK] = f
+		}
+	}
+	return &ObjectCleanerImpl{
+		KnownTypes: kt,
+	}
+}
+
+func (oc *ObjectCleanerImpl) Cleanup(obj *unstructured.Unstructured) error {
+	gvk := obj.GroupVersionKind()
+	gk := gvk.GroupKind()
+
+	if gk.Kind == "" || gvk.Version == "" { // Group can be empty e.g. built-in objects like ConfigMap
+		return fmt.Errorf("object %q has empty kind/version: %v", obj.GetName(), gvk)
+	}
+
+	// Check if it is a known built-in resource
+	if removeIgnoredFields, ok := oc.KnownTypes[gk]; ok {
+		return removeIgnoredFields(obj)
+	}
+
+	return nil
+}

--- a/pkg/cleanup/object_cleanup_test.go
+++ b/pkg/cleanup/object_cleanup_test.go
@@ -1,0 +1,8 @@
+package cleanup
+
+import "testing"
+
+func TestSpecProcessor(t *testing.T) {
+	t.Parallel()
+
+}

--- a/pkg/cleanup/object_cleanup_test.go
+++ b/pkg/cleanup/object_cleanup_test.go
@@ -1,8 +1,0 @@
-package cleanup
-
-import "testing"
-
-func TestSpecProcessor(t *testing.T) {
-	t.Parallel()
-
-}

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/atlassian/smith"
 	"github.com/atlassian/smith/pkg/cleanup"
-	"github.com/atlassian/smith/pkg/util/wait"
 
 	"github.com/ash2k/stager/wait"
 	"k8s.io/apimachinery/pkg/runtime"

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -40,7 +40,7 @@ type BundleController struct {
 	queue   workqueue.RateLimitingInterface
 	workers int
 	// Server fields cleanup
-	cleaner cleanup.ObjectCleaner
+	cleaner cleanup.SpecCleaner
 
 	// TPR
 	tprResyncPeriod time.Duration
@@ -49,7 +49,7 @@ type BundleController struct {
 
 func New(bundleInf, tprInf cache.SharedIndexInformer, bundleClient *rest.RESTClient, bundleStore BundleStore,
 	sc smith.SmartClient, rc ReadyChecker, scheme *runtime.Scheme, store Store, queue workqueue.RateLimitingInterface,
-	workers int, cleaner cleanup.ObjectCleaner, tprResyncPeriod time.Duration, resourceInfs map[schema.GroupVersionKind]cache.SharedIndexInformer) *BundleController {
+	workers int, cleaner cleanup.SpecCleaner, tprResyncPeriod time.Duration, resourceInfs map[schema.GroupVersionKind]cache.SharedIndexInformer) *BundleController {
 	c := &BundleController{
 		bundleInf:       bundleInf,
 		tprInf:          tprInf,

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -6,6 +6,8 @@ import (
 	"time"
 
 	"github.com/atlassian/smith"
+	"github.com/atlassian/smith/pkg/cleanup"
+	"github.com/atlassian/smith/pkg/util/wait"
 
 	"github.com/ash2k/stager/wait"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -37,6 +39,8 @@ type BundleController struct {
 	// Bundle objects that need to be synced.
 	queue   workqueue.RateLimitingInterface
 	workers int
+	// Server fields cleanup
+	cleaner cleanup.ObjectCleaner
 
 	// TPR
 	tprResyncPeriod time.Duration
@@ -45,7 +49,7 @@ type BundleController struct {
 
 func New(bundleInf, tprInf cache.SharedIndexInformer, bundleClient *rest.RESTClient, bundleStore BundleStore,
 	sc smith.SmartClient, rc ReadyChecker, scheme *runtime.Scheme, store Store, queue workqueue.RateLimitingInterface,
-	workers int, tprResyncPeriod time.Duration, resourceInfs map[schema.GroupVersionKind]cache.SharedIndexInformer) *BundleController {
+	workers int, cleaner cleanup.ObjectCleaner, tprResyncPeriod time.Duration, resourceInfs map[schema.GroupVersionKind]cache.SharedIndexInformer) *BundleController {
 	c := &BundleController{
 		bundleInf:       bundleInf,
 		tprInf:          tprInf,
@@ -57,6 +61,7 @@ func New(bundleInf, tprInf cache.SharedIndexInformer, bundleClient *rest.RESTCli
 		store:           store,
 		queue:           queue,
 		workers:         workers,
+		cleaner:         cleaner,
 		tprResyncPeriod: tprResyncPeriod,
 	}
 	bundleInf.AddEventHandler(cache.ResourceEventHandlerFuncs{

--- a/pkg/controller/controller_worker.go
+++ b/pkg/controller/controller_worker.go
@@ -571,7 +571,10 @@ func (c *BundleController) compareActualVsSpec(spec, actual *unstructured.Unstru
 	setOwnerReferences(updated, spec.GetOwnerReferences())
 	updated.SetFinalizers(spec.GetFinalizers()) // TODO Is this ok?
 
-	// 3. Everything else
+	// 3. Ignore fields managed by server
+	c.cleaner.Cleanup(updated)
+
+	// 4. Everything else
 	for field, specValue := range spec.Object {
 		switch field {
 		case "kind", "apiVersion", "metadata":

--- a/pkg/controller/controller_worker.go
+++ b/pkg/controller/controller_worker.go
@@ -572,7 +572,13 @@ func (c *BundleController) compareActualVsSpec(spec, actual *unstructured.Unstru
 	updated.SetFinalizers(spec.GetFinalizers()) // TODO Is this ok?
 
 	// 3. Ignore fields managed by server
-	c.cleaner.Cleanup(updated)
+	//c.cleaner.Cleanup(updated)
+	log.Printf("Before: %v\n", &updated.Object)
+	updated, err = c.cleaner.Cleanup(updated)
+	if err != nil {
+		return nil, false, err
+	}
+	log.Printf("After: %v\n", &updated.Object)
 
 	// 4. Everything else
 	for field, specValue := range spec.Object {
@@ -583,6 +589,7 @@ func (c *BundleController) compareActualVsSpec(spec, actual *unstructured.Unstru
 		updated.Object[field] = specValue // using the value directly - we've made a copy up the stack so it's ok
 	}
 	if !equality.Semantic.DeepEqual(updated.Object, actualClone.Object) {
+		log.Printf("Updated: %v\n", &updated.Object)
 		log.Printf("Objects are different: %s\nupdated: %v\nactualClone: %v",
 			diff.ObjectReflectDiff(updated.Object, actualClone.Object), updated.Object, actualClone.Object)
 		return updated, false, nil

--- a/pkg/controller/controller_worker_test.go
+++ b/pkg/controller/controller_worker_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/atlassian/smith/pkg/cleanup"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -26,7 +27,8 @@ func TestUpdateResourceEmptyMissingNilNoChanges(t *testing.T) {
 			t.Run(fmt.Sprintf("%s actual, %s desired", kind1, kind2), func(t *testing.T) {
 				t.Parallel()
 				cntrlr := BundleController{
-					scheme: runtime.NewScheme(),
+					scheme:  runtime.NewScheme(),
+					cleaner: cleanup.New(),
 				}
 				updated, match, err := cntrlr.compareActualVsSpec(desired, actual)
 				require.NoError(t, err)


### PR DESCRIPTION
Another fix for https://github.com/atlassian/smith/issues/84, companion for https://github.com/atlassian/smith/pull/86:
- Add support for ignoring particular fields (managed by server, not part of the client spec)
- No generic support for TPRs and other types yet
- No integration test yet (but manual check succeeded)

Merge https://github.com/atlassian/smith/pull/86 first, then fix conflicts and and missing bits