### PR TITLE
Migrate tests to ListWatchUntil

### DIFF
--- a/integration_tests/adoption_test.go
+++ b/integration_tests/adoption_test.go
@@ -113,9 +113,7 @@ func testAdoption(t *testing.T, ctxTest context.Context, cfg *itConfig, args ...
 	time.Sleep(1 * time.Second) // TODO this should be removed once race with tpr informer is fixed "no informer for tpr.atlassian.com/v1, Kind=Sleeper is registered"
 
 	// Bundle should be in Error=true state
-	obj, err := cfg.store.AwaitObjectCondition(ctxTest, smith.BundleGVK, cfg.namespace, cfg.bundle.Name, isBundleError)
-	require.NoError(t, err)
-	bundleActual = obj.(*smith.Bundle)
+	bundleActual = cfg.awaitBundleCondition(isBundleStatusCond(smith.BundleError, smith.ConditionTrue))
 
 	assertCondition(t, bundleActual, smith.BundleReady, smith.ConditionFalse)
 	assertCondition(t, bundleActual, smith.BundleInProgress, smith.ConditionFalse)
@@ -174,7 +172,7 @@ func testAdoption(t *testing.T, ctxTest context.Context, cfg *itConfig, args ...
 	}
 
 	// Bundle should reach Ready=true state
-	assertBundle(t, ctxTest, cfg.store, cfg.namespace, cfg.bundle)
+	cfg.assertBundle(ctxTest, cfg.bundle)
 
 	// ConfigMap should have BlockOwnerDeletion updated
 	cmActual, err = cmClient.Get(cm.Name, meta_v1.GetOptions{})

--- a/integration_tests/crd_attribute_test.go
+++ b/integration_tests/crd_attribute_test.go
@@ -70,7 +70,7 @@ func testCrdAttribute(t *testing.T, ctxTest context.Context, cfg *itConfig, args
 	ctxTimeout, cancel := context.WithTimeout(ctxTest, time.Duration(sl.Spec.SleepFor+3)*time.Second)
 	defer cancel()
 
-	assertBundle(t, ctxTimeout, cfg.store, cfg.namespace, cfg.bundle, "")
+	cfg.assertBundle(ctxTimeout, cfg.bundle, "")
 
 	var sleeperObj sleeper.Sleeper
 	require.NoError(t, sClient.Get().

--- a/integration_tests/main_test.go
+++ b/integration_tests/main_test.go
@@ -75,7 +75,7 @@ func TestWorkflow(t *testing.T) {
 }
 
 func testWorkflow(t *testing.T, ctx context.Context, cfg *itConfig, args ...interface{}) {
-	bundleRes := assertBundleTimeout(t, ctx, cfg.store, cfg.namespace, cfg.bundle, cfg.createdBundle.ResourceVersion)
+	bundleRes := cfg.assertBundleTimeout(ctx, cfg.bundle, cfg.createdBundle.ResourceVersion)
 
 	cfMap, err := cfg.clientset.CoreV1().ConfigMaps(cfg.namespace).Get("config1", meta_v1.GetOptions{})
 	require.NoError(t, err)

--- a/integration_tests/resource_deletion_test.go
+++ b/integration_tests/resource_deletion_test.go
@@ -112,9 +112,7 @@ func testResourceDeletion(t *testing.T, ctxTest context.Context, cfg *itConfig, 
 	time.Sleep(1 * time.Second) // TODO this should be removed once race with tpr informer is fixed "no informer for tpr.atlassian.com/v1, Kind=Sleeper is registered"
 
 	// Bundle should be in Error=true state
-	obj, err := cfg.store.AwaitObjectCondition(ctxTest, smith.BundleGVK, cfg.namespace, cfg.bundle.Name, isBundleError)
-	require.NoError(t, err)
-	bundleActual = obj.(*smith.Bundle)
+	bundleActual = cfg.awaitBundleCondition(isBundleStatusCond(smith.BundleError, smith.ConditionTrue))
 
 	assertCondition(t, bundleActual, smith.BundleReady, smith.ConditionFalse)
 	assertCondition(t, bundleActual, smith.BundleInProgress, smith.ConditionFalse)
@@ -157,7 +155,7 @@ func testResourceDeletion(t *testing.T, ctxTest context.Context, cfg *itConfig, 
 	require.NoError(t, err)
 
 	// Bundle should reach Ready=true state
-	assertBundle(t, ctxTest, cfg.store, cfg.namespace, cfg.bundle)
+	cfg.assertBundle(ctxTest, cfg.bundle)
 
 	// ConfigMap should exist by now
 	cmActual, err = cmClient.Get(cm.Name, meta_v1.GetOptions{})

--- a/integration_tests/service_catalog_test.go
+++ b/integration_tests/service_catalog_test.go
@@ -68,5 +68,5 @@ func TestServiceCatalog(t *testing.T) {
 }
 
 func testServiceCatalog(t *testing.T, ctx context.Context, cfg *itConfig, args ...interface{}) {
-	assertBundleTimeout(t, ctx, cfg.store, cfg.namespace, cfg.bundle, "")
+	cfg.assertBundleTimeout(ctx, cfg.bundle, "")
 }

--- a/integration_tests/update_test.go
+++ b/integration_tests/update_test.go
@@ -165,7 +165,7 @@ func testUpdate(t *testing.T, ctxTest context.Context, cfg *itConfig, args ...in
 	ctxTimeout, cancel := context.WithTimeout(ctxTest, time.Duration(sleeper1.Spec.SleepFor+2)*time.Second)
 	defer cancel()
 
-	bundleRes1 := assertBundle(t, ctxTimeout, cfg.store, cfg.namespace, cfg.bundle, cfg.createdBundle.ResourceVersion)
+	bundleRes1 := cfg.assertBundle(ctxTimeout, cfg.bundle, cfg.createdBundle.ResourceVersion)
 
 	res := &smith.Bundle{}
 	bundle2.ResourceVersion = bundleRes1.ResourceVersion
@@ -178,7 +178,7 @@ func testUpdate(t *testing.T, ctxTest context.Context, cfg *itConfig, args ...in
 		Do().
 		Into(res))
 
-	bundleRes2 := assertBundle(t, ctxTimeout, cfg.store, cfg.namespace, bundle2, bundle2.ResourceVersion, res.ResourceVersion)
+	bundleRes2 := cfg.assertBundle(ctxTimeout, bundle2, bundle2.ResourceVersion, res.ResourceVersion)
 
 	cfMap, err := cmClient.Get(cm2.Name, meta_v1.GetOptions{})
 	require.NoError(t, err)
@@ -220,7 +220,7 @@ func testUpdate(t *testing.T, ctxTest context.Context, cfg *itConfig, args ...in
 		Do().
 		Into(res))
 
-	assertBundleTimeout(t, ctxTest, cfg.store, cfg.namespace, &emptyBundle, emptyBundle.ResourceVersion, res.ResourceVersion)
+	cfg.assertBundleTimeout(ctxTest, &emptyBundle, emptyBundle.ResourceVersion, res.ResourceVersion)
 
 	cfMap, err = cmClient.Get(cm2.Name, meta_v1.GetOptions{})
 	if err == nil {


### PR DESCRIPTION
I'll be removing `Multi.AwaitObjectCondition()` so need to remove all usages.