### PR TITLE
Move api types to match standard directory layout

### DIFF
--- a/api.go
+++ b/api.go
@@ -1,0 +1,11 @@
+package smith
+
+const (
+	Domain = "smith.atlassian.com"
+
+	// See docs/design/managing-resources.md
+	CrFieldPathAnnotation  = Domain + "/CrReadyWhenFieldPath"
+	CrFieldValueAnnotation = Domain + "/CrReadyWhenFieldValue"
+
+	BundleNameLabel = Domain + "/BundleName"
+)

--- a/cmd/smith/app/app.go
+++ b/cmd/smith/app/app.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/atlassian/smith"
+	smith_v1 "github.com/atlassian/smith/pkg/apis/smith/v1"
 	"github.com/atlassian/smith/pkg/cleanup"
 	clean_types "github.com/atlassian/smith/pkg/cleanup/types"
 	"github.com/atlassian/smith/pkg/client"
@@ -60,7 +61,11 @@ func (a *App) Run(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	bundleClient, err := client.BundleClient(a.RestConfig, client.BundleScheme())
+	bundleScheme, err := client.BundleScheme()
+	if err != nil {
+		return err
+	}
+	bundleClient, err := client.BundleClient(a.RestConfig, bundleScheme)
 	if err != nil {
 		return err
 	}
@@ -90,7 +95,7 @@ func (a *App) Run(ctx context.Context) error {
 
 	// Informers
 	bundleInf := client.BundleInformer(bundleClient, a.Namespace, a.ResyncPeriod)
-	multiStore.AddInformer(smith.BundleGVK, bundleInf)
+	multiStore.AddInformer(smith_v1.BundleGVK, bundleInf)
 
 	informerFactory := crdInformers.NewSharedInformerFactory(crdClient, a.ResyncPeriod)
 	crdInf := informerFactory.Apiextensions().V1beta1().CustomResourceDefinitions().Informer()
@@ -116,7 +121,7 @@ func (a *App) Run(ctx context.Context) error {
 			if err == context.Canceled || err == context.DeadlineExceeded {
 				return true, err
 			}
-			log.Printf("Failed to create CRD %s: %v", smith.BundleResourceName, err)
+			log.Printf("Failed to create CRD %s: %v", smith_v1.BundleResourceName, err)
 			return false, nil
 		}
 		return true, nil

--- a/cmd/smith/app/types.go
+++ b/cmd/smith/app/types.go
@@ -1,7 +1,7 @@
 package app
 
 import (
-	"github.com/atlassian/smith"
+	smith_v1 "github.com/atlassian/smith/pkg/apis/smith/v1"
 
 	sc_v1a1 "github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog/v1alpha1"
 	apiext_v1b1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
@@ -19,8 +19,8 @@ var (
 
 func FullScheme(serviceCatalog bool) (*runtime.Scheme, error) {
 	scheme := runtime.NewScheme()
-	smith.AddToScheme(scheme)
 	var sb runtime.SchemeBuilder
+	sb.Register(smith_v1.SchemeBuilder...)
 	sb.Register(ext_v1b1.SchemeBuilder...)
 	sb.Register(api_v1.SchemeBuilder...)
 	sb.Register(apps_v1b1.SchemeBuilder...)
@@ -28,9 +28,8 @@ func FullScheme(serviceCatalog bool) (*runtime.Scheme, error) {
 	sb.Register(apiext_v1b1.SchemeBuilder...)
 	if serviceCatalog {
 		sb.Register(sc_v1a1.SchemeBuilder...)
-	} else {
-		scheme.AddUnversionedTypes(api_v1.SchemeGroupVersion, &meta_v1.Status{})
 	}
+	scheme.AddUnversionedTypes(api_v1.SchemeGroupVersion, &meta_v1.Status{})
 	if err := sb.AddToScheme(scheme); err != nil {
 		return nil, err
 	}

--- a/integration_tests/adoption_test.go
+++ b/integration_tests/adoption_test.go
@@ -7,8 +7,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/atlassian/smith"
 	"github.com/atlassian/smith/examples/sleeper"
+	smith_v1 "github.com/atlassian/smith/pkg/apis/smith/v1"
 
 	"github.com/ash2k/stager"
 	"github.com/stretchr/testify/assert"
@@ -44,22 +44,22 @@ func TestAdoption(t *testing.T) {
 			WakeupMessage: "Hello there!",
 		},
 	}
-	bundle := &smith.Bundle{
+	bundle := &smith_v1.Bundle{
 		TypeMeta: meta_v1.TypeMeta{
-			Kind:       smith.BundleResourceKind,
-			APIVersion: smith.BundleResourceGroupVersion,
+			Kind:       smith_v1.BundleResourceKind,
+			APIVersion: smith_v1.BundleResourceGroupVersion,
 		},
 		ObjectMeta: meta_v1.ObjectMeta{
 			Name: "bundle",
 		},
-		Spec: smith.BundleSpec{
-			Resources: []smith.Resource{
+		Spec: smith_v1.BundleSpec{
+			Resources: []smith_v1.Resource{
 				{
-					Name: smith.ResourceName(cm.Name),
+					Name: smith_v1.ResourceName(cm.Name),
 					Spec: cm,
 				},
 				{
-					Name: smith.ResourceName(sleeper.Name),
+					Name: smith_v1.ResourceName(sleeper.Name),
 					Spec: sleeper,
 				},
 			},
@@ -106,18 +106,18 @@ func testAdoption(t *testing.T, ctxTest context.Context, cfg *itConfig, args ...
 	cfg.cleanupLater(sleeperActual)
 
 	// Create Bundle with same resources
-	bundleActual := &smith.Bundle{}
-	cfg.createObject(ctxTest, cfg.bundle, bundleActual, smith.BundleResourcePlural, cfg.bundleClient)
+	bundleActual := &smith_v1.Bundle{}
+	cfg.createObject(ctxTest, cfg.bundle, bundleActual, smith_v1.BundleResourcePlural, cfg.bundleClient)
 	cfg.createdBundle = bundleActual
 
 	time.Sleep(1 * time.Second) // TODO this should be removed once race with tpr informer is fixed "no informer for tpr.atlassian.com/v1, Kind=Sleeper is registered"
 
 	// Bundle should be in Error=true state
-	bundleActual = cfg.awaitBundleCondition(isBundleStatusCond(cfg.namespace, cfg.bundle.Name, smith.BundleError, smith.ConditionTrue))
+	bundleActual = cfg.awaitBundleCondition(isBundleStatusCond(cfg.namespace, cfg.bundle.Name, smith_v1.BundleError, smith_v1.ConditionTrue))
 
-	assertCondition(t, bundleActual, smith.BundleReady, smith.ConditionFalse)
-	assertCondition(t, bundleActual, smith.BundleInProgress, smith.ConditionFalse)
-	cond := assertCondition(t, bundleActual, smith.BundleError, smith.ConditionTrue)
+	assertCondition(t, bundleActual, smith_v1.BundleReady, smith_v1.ConditionFalse)
+	assertCondition(t, bundleActual, smith_v1.BundleInProgress, smith_v1.ConditionFalse)
+	cond := assertCondition(t, bundleActual, smith_v1.BundleError, smith_v1.ConditionTrue)
 	if cond != nil {
 		assert.Equal(t, "TerminalError", cond.Reason)
 		assert.Equal(t, "object /v1, Kind=ConfigMap \"cm\" is not owned by the Bundle", cond.Message)
@@ -127,8 +127,8 @@ func testAdoption(t *testing.T, ctxTest context.Context, cfg *itConfig, args ...
 	trueVar := true
 	cmActual.OwnerReferences = []meta_v1.OwnerReference{
 		{
-			APIVersion: smith.BundleResourceGroupVersion,
-			Kind:       smith.BundleResourceKind,
+			APIVersion: smith_v1.BundleResourceGroupVersion,
+			Kind:       smith_v1.BundleResourceKind,
 			Name:       bundleActual.Name,
 			UID:        bundleActual.UID,
 			Controller: &trueVar,
@@ -141,8 +141,8 @@ func testAdoption(t *testing.T, ctxTest context.Context, cfg *itConfig, args ...
 	for { // Retry loop to handle conflicts with Sleeper controller
 		sleeperActual.SetOwnerReferences([]meta_v1.OwnerReference{
 			{
-				APIVersion: smith.BundleResourceGroupVersion,
-				Kind:       smith.BundleResourceKind,
+				APIVersion: smith_v1.BundleResourceGroupVersion,
+				Kind:       smith_v1.BundleResourceKind,
 				Name:       bundleActual.Name,
 				UID:        bundleActual.UID,
 				Controller: &trueVar,
@@ -179,8 +179,8 @@ func testAdoption(t *testing.T, ctxTest context.Context, cfg *itConfig, args ...
 	require.NoError(t, err)
 	assert.Equal(t, []meta_v1.OwnerReference{
 		{
-			APIVersion:         smith.BundleResourceGroupVersion,
-			Kind:               smith.BundleResourceKind,
+			APIVersion:         smith_v1.BundleResourceGroupVersion,
+			Kind:               smith_v1.BundleResourceKind,
 			Name:               bundleActual.Name,
 			UID:                bundleActual.UID,
 			Controller:         &trueVar,
@@ -199,8 +199,8 @@ func testAdoption(t *testing.T, ctxTest context.Context, cfg *itConfig, args ...
 	require.NoError(t, err)
 	assert.Equal(t, []meta_v1.OwnerReference{
 		{
-			APIVersion:         smith.BundleResourceGroupVersion,
-			Kind:               smith.BundleResourceKind,
+			APIVersion:         smith_v1.BundleResourceGroupVersion,
+			Kind:               smith_v1.BundleResourceKind,
 			Name:               bundleActual.Name,
 			UID:                bundleActual.UID,
 			Controller:         &trueVar,

--- a/integration_tests/crd_attribute_test.go
+++ b/integration_tests/crd_attribute_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/atlassian/smith"
 	"github.com/atlassian/smith/examples/sleeper"
+	smith_v1 "github.com/atlassian/smith/pkg/apis/smith/v1"
 
 	"github.com/ash2k/stager"
 	"github.com/stretchr/testify/assert"
@@ -30,18 +31,18 @@ func TestCrdAttribute(t *testing.T) {
 			WakeupMessage: "Hello, Infravators!",
 		},
 	}
-	bundle := &smith.Bundle{
+	bundle := &smith_v1.Bundle{
 		TypeMeta: meta_v1.TypeMeta{
-			Kind:       smith.BundleResourceKind,
-			APIVersion: smith.BundleResourceGroupVersion,
+			Kind:       smith_v1.BundleResourceKind,
+			APIVersion: smith_v1.BundleResourceGroupVersion,
 		},
 		ObjectMeta: meta_v1.ObjectMeta{
 			Name: "bundle-attribute",
 		},
-		Spec: smith.BundleSpec{
-			Resources: []smith.Resource{
+		Spec: smith_v1.BundleSpec{
+			Resources: []smith_v1.Resource{
 				{
-					Name: smith.ResourceName(sl.Name),
+					Name: smith_v1.ResourceName(sl.Name),
 					Spec: sl,
 				},
 			},

--- a/integration_tests/main_test.go
+++ b/integration_tests/main_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/atlassian/smith"
+	smith_v1 "github.com/atlassian/smith/pkg/apis/smith/v1"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -44,10 +45,10 @@ func TestWorkflow(t *testing.T) {
 			"a": "b",
 		},
 	}
-	bundle := &smith.Bundle{
+	bundle := &smith_v1.Bundle{
 		TypeMeta: meta_v1.TypeMeta{
-			Kind:       smith.BundleResourceKind,
-			APIVersion: smith.BundleResourceGroupVersion,
+			Kind:       smith_v1.BundleResourceKind,
+			APIVersion: smith_v1.BundleResourceGroupVersion,
 		},
 		ObjectMeta: meta_v1.ObjectMeta{
 			Name: "bundle1",
@@ -57,11 +58,11 @@ func TestWorkflow(t *testing.T) {
 				smith.BundleNameLabel: "bundleLabel123",
 			},
 		},
-		Spec: smith.BundleSpec{
-			Resources: []smith.Resource{
+		Spec: smith_v1.BundleSpec{
+			Resources: []smith_v1.Resource{
 				{
 					Name:      "config1res",
-					DependsOn: []smith.ResourceName{"secret2res"},
+					DependsOn: []smith_v1.ResourceName{"secret2res"},
 					Spec:      c1,
 				},
 				{
@@ -91,8 +92,8 @@ func testWorkflow(t *testing.T, ctx context.Context, cfg *itConfig, args ...inte
 	trueRef := true
 	assert.Equal(t, []meta_v1.OwnerReference{
 		{
-			APIVersion:         smith.BundleResourceGroupVersion,
-			Kind:               smith.BundleResourceKind,
+			APIVersion:         smith_v1.BundleResourceGroupVersion,
+			Kind:               smith_v1.BundleResourceKind,
 			Name:               bundleRes.Name,
 			UID:                bundleRes.UID,
 			Controller:         &trueRef,
@@ -108,8 +109,8 @@ func testWorkflow(t *testing.T, ctx context.Context, cfg *itConfig, args ...inte
 	}, cfMap.GetOwnerReferences())
 	assert.Equal(t, []meta_v1.OwnerReference{
 		{
-			APIVersion:         smith.BundleResourceGroupVersion,
-			Kind:               smith.BundleResourceKind,
+			APIVersion:         smith_v1.BundleResourceGroupVersion,
+			Kind:               smith_v1.BundleResourceKind,
 			Name:               bundleRes.Name,
 			UID:                bundleRes.UID,
 			Controller:         &trueRef,

--- a/integration_tests/resource_deletion_test.go
+++ b/integration_tests/resource_deletion_test.go
@@ -7,8 +7,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/atlassian/smith"
 	"github.com/atlassian/smith/examples/sleeper"
+	smith_v1 "github.com/atlassian/smith/pkg/apis/smith/v1"
 
 	"github.com/ash2k/stager"
 	"github.com/stretchr/testify/assert"
@@ -43,22 +43,22 @@ func TestResourceDeletion(t *testing.T) {
 			WakeupMessage: "Hello there!",
 		},
 	}
-	bundle := &smith.Bundle{
+	bundle := &smith_v1.Bundle{
 		TypeMeta: meta_v1.TypeMeta{
-			Kind:       smith.BundleResourceKind,
-			APIVersion: smith.BundleResourceGroupVersion,
+			Kind:       smith_v1.BundleResourceKind,
+			APIVersion: smith_v1.BundleResourceGroupVersion,
 		},
 		ObjectMeta: meta_v1.ObjectMeta{
 			Name: "bundle",
 		},
-		Spec: smith.BundleSpec{
-			Resources: []smith.Resource{
+		Spec: smith_v1.BundleSpec{
+			Resources: []smith_v1.Resource{
 				{
-					Name: smith.ResourceName(cm.Name),
+					Name: smith_v1.ResourceName(cm.Name),
 					Spec: cm,
 				},
 				{
-					Name: smith.ResourceName(sl.Name),
+					Name: smith_v1.ResourceName(sl.Name),
 					Spec: sl,
 				},
 			},
@@ -105,18 +105,18 @@ func testResourceDeletion(t *testing.T, ctxTest context.Context, cfg *itConfig, 
 	cfg.cleanupLater(sleeperActual)
 
 	// Create Bundle with same resources
-	bundleActual := &smith.Bundle{}
-	cfg.createObject(ctxTest, cfg.bundle, bundleActual, smith.BundleResourcePlural, cfg.bundleClient)
+	bundleActual := &smith_v1.Bundle{}
+	cfg.createObject(ctxTest, cfg.bundle, bundleActual, smith_v1.BundleResourcePlural, cfg.bundleClient)
 	cfg.createdBundle = bundleActual
 
 	time.Sleep(1 * time.Second) // TODO this should be removed once race with tpr informer is fixed "no informer for tpr.atlassian.com/v1, Kind=Sleeper is registered"
 
 	// Bundle should be in Error=true state
-	bundleActual = cfg.awaitBundleCondition(isBundleStatusCond(cfg.namespace, cfg.bundle.Name, smith.BundleError, smith.ConditionTrue))
+	bundleActual = cfg.awaitBundleCondition(isBundleStatusCond(cfg.namespace, cfg.bundle.Name, smith_v1.BundleError, smith_v1.ConditionTrue))
 
-	assertCondition(t, bundleActual, smith.BundleReady, smith.ConditionFalse)
-	assertCondition(t, bundleActual, smith.BundleInProgress, smith.ConditionFalse)
-	cond := assertCondition(t, bundleActual, smith.BundleError, smith.ConditionTrue)
+	assertCondition(t, bundleActual, smith_v1.BundleReady, smith_v1.ConditionFalse)
+	assertCondition(t, bundleActual, smith_v1.BundleInProgress, smith_v1.ConditionFalse)
+	cond := assertCondition(t, bundleActual, smith_v1.BundleError, smith_v1.ConditionTrue)
 	if cond != nil {
 		assert.Equal(t, "TerminalError", cond.Reason)
 		assert.Equal(t, "object /v1, Kind=ConfigMap \"cm\" is not owned by the Bundle", cond.Message)
@@ -126,8 +126,8 @@ func testResourceDeletion(t *testing.T, ctxTest context.Context, cfg *itConfig, 
 	trueVar := true
 	cmActual.OwnerReferences = []meta_v1.OwnerReference{
 		{
-			APIVersion: smith.BundleResourceGroupVersion,
-			Kind:       smith.BundleResourceKind,
+			APIVersion: smith_v1.BundleResourceGroupVersion,
+			Kind:       smith_v1.BundleResourceKind,
 			Name:       bundleActual.Name,
 			UID:        bundleActual.UID,
 			Controller: &trueVar,

--- a/integration_tests/service_catalog_test.go
+++ b/integration_tests/service_catalog_test.go
@@ -6,7 +6,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/atlassian/smith"
+	smith_v1 "github.com/atlassian/smith/pkg/apis/smith/v1"
 
 	sc_v1a1 "github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog/v1alpha1"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -42,23 +42,23 @@ func TestServiceCatalog(t *testing.T) {
 			SecretName: "secret1",
 		},
 	}
-	bundle := &smith.Bundle{
+	bundle := &smith_v1.Bundle{
 		TypeMeta: meta_v1.TypeMeta{
-			Kind:       smith.BundleResourceKind,
-			APIVersion: smith.BundleResourceGroupVersion,
+			Kind:       smith_v1.BundleResourceKind,
+			APIVersion: smith_v1.BundleResourceGroupVersion,
 		},
 		ObjectMeta: meta_v1.ObjectMeta{
 			Name: "bundle-cs",
 		},
-		Spec: smith.BundleSpec{
-			Resources: []smith.Resource{
+		Spec: smith_v1.BundleSpec{
+			Resources: []smith_v1.Resource{
 				{
-					Name: smith.ResourceName(instance.Name),
+					Name: smith_v1.ResourceName(instance.Name),
 					Spec: instance,
 				},
 				{
-					Name:      smith.ResourceName(binding.Name),
-					DependsOn: []smith.ResourceName{smith.ResourceName(instance.Name)},
+					Name:      smith_v1.ResourceName(binding.Name),
+					DependsOn: []smith_v1.ResourceName{smith_v1.ResourceName(instance.Name)},
 					Spec:      binding,
 				},
 			},

--- a/integration_tests/update_test.go
+++ b/integration_tests/update_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/atlassian/smith"
 	"github.com/atlassian/smith/examples/sleeper"
+	smith_v1 "github.com/atlassian/smith/pkg/apis/smith/v1"
 
 	"github.com/ash2k/stager"
 	"github.com/stretchr/testify/assert"
@@ -85,10 +86,10 @@ func TestUpdate(t *testing.T) {
 			WakeupMessage: "Hello, martians!",
 		},
 	}
-	bundle1 := &smith.Bundle{
+	bundle1 := &smith_v1.Bundle{
 		TypeMeta: meta_v1.TypeMeta{
-			Kind:       smith.BundleResourceKind,
-			APIVersion: smith.BundleResourceGroupVersion,
+			Kind:       smith_v1.BundleResourceKind,
+			APIVersion: smith_v1.BundleResourceGroupVersion,
 		},
 		ObjectMeta: meta_v1.ObjectMeta{
 			Name: "bundle1",
@@ -98,23 +99,23 @@ func TestUpdate(t *testing.T) {
 				smith.BundleNameLabel: "bundleLabel1",
 			},
 		},
-		Spec: smith.BundleSpec{
-			Resources: []smith.Resource{
+		Spec: smith_v1.BundleSpec{
+			Resources: []smith_v1.Resource{
 				{
-					Name: smith.ResourceName(cm1.Name),
+					Name: smith_v1.ResourceName(cm1.Name),
 					Spec: cm1,
 				},
 				{
-					Name: smith.ResourceName(sleeper1.Name),
+					Name: smith_v1.ResourceName(sleeper1.Name),
 					Spec: sleeper1,
 				},
 			},
 		},
 	}
-	bundle2 := &smith.Bundle{
+	bundle2 := &smith_v1.Bundle{
 		TypeMeta: meta_v1.TypeMeta{
-			Kind:       smith.BundleResourceKind,
-			APIVersion: smith.BundleResourceGroupVersion,
+			Kind:       smith_v1.BundleResourceKind,
+			APIVersion: smith_v1.BundleResourceGroupVersion,
 		},
 		ObjectMeta: meta_v1.ObjectMeta{
 			Name: "bundle1",
@@ -124,14 +125,14 @@ func TestUpdate(t *testing.T) {
 				smith.BundleNameLabel: "bundleLabel2",
 			},
 		},
-		Spec: smith.BundleSpec{
-			Resources: []smith.Resource{
+		Spec: smith_v1.BundleSpec{
+			Resources: []smith_v1.Resource{
 				{
-					Name: smith.ResourceName(cm2.Name),
+					Name: smith_v1.ResourceName(cm2.Name),
 					Spec: cm2,
 				},
 				{
-					Name: smith.ResourceName(sleeper2.Name),
+					Name: smith_v1.ResourceName(sleeper2.Name),
 					Spec: sleeper2,
 				},
 			},
@@ -156,7 +157,7 @@ func testUpdate(t *testing.T, ctxTest context.Context, cfg *itConfig, args ...in
 	cm2 := args[0].(*api_v1.ConfigMap)
 	sleeper1 := args[1].(*sleeper.Sleeper)
 	sleeper2 := args[2].(*sleeper.Sleeper)
-	bundle2 := args[3].(*smith.Bundle)
+	bundle2 := args[3].(*smith_v1.Bundle)
 
 	cmClient := cfg.clientset.CoreV1().ConfigMaps(cfg.namespace)
 	sClient, err := sleeper.GetSleeperClient(cfg.config, sleeperScheme())
@@ -167,12 +168,12 @@ func testUpdate(t *testing.T, ctxTest context.Context, cfg *itConfig, args ...in
 
 	bundleRes1 := cfg.assertBundle(ctxTimeout, cfg.bundle, cfg.createdBundle.ResourceVersion)
 
-	res := &smith.Bundle{}
+	res := &smith_v1.Bundle{}
 	bundle2.ResourceVersion = bundleRes1.ResourceVersion
 	require.NoError(t, cfg.bundleClient.Put().
 		Context(ctxTest).
 		Namespace(cfg.namespace).
-		Resource(smith.BundleResourcePlural).
+		Resource(smith_v1.BundleResourcePlural).
 		Name(bundle2.Name).
 		Body(bundle2).
 		Do().
@@ -209,12 +210,12 @@ func testUpdate(t *testing.T, ctxTest context.Context, cfg *itConfig, args ...in
 	assert.Equal(t, sleeper2.Spec, sleeperObj.Spec)
 
 	emptyBundle := *cfg.bundle
-	emptyBundle.Spec.Resources = []smith.Resource{}
+	emptyBundle.Spec.Resources = []smith_v1.Resource{}
 	emptyBundle.ResourceVersion = bundleRes2.ResourceVersion
 	require.NoError(t, cfg.bundleClient.Put().
 		Context(ctxTest).
 		Namespace(cfg.namespace).
-		Resource(smith.BundleResourcePlural).
+		Resource(smith_v1.BundleResourcePlural).
 		Name(emptyBundle.Name).
 		Body(&emptyBundle).
 		Do().

--- a/pkg/apis/smith/v1/register.go
+++ b/pkg/apis/smith/v1/register.go
@@ -1,0 +1,38 @@
+package v1
+
+import (
+	"github.com/atlassian/smith"
+
+	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// GroupName is the group name use in this package.
+const GroupName = smith.Domain
+
+// SchemeGroupVersion is group version used to register these objects.
+var SchemeGroupVersion = schema.GroupVersion{Group: GroupName, Version: "v1"}
+
+// Kind takes an unqualified kind and returns a Group qualified GroupKind.
+func Kind(kind string) schema.GroupKind {
+	return SchemeGroupVersion.WithKind(kind).GroupKind()
+}
+
+var (
+	// SchemeBuilder needs to be exported as `SchemeBuilder` so
+	// the code-generation can find it.
+	SchemeBuilder = runtime.NewSchemeBuilder(addKnownTypes)
+	// AddToScheme is exposed for API installation
+	AddToScheme = SchemeBuilder.AddToScheme
+)
+
+func addKnownTypes(scheme *runtime.Scheme) error {
+	scheme.AddKnownTypes(SchemeGroupVersion,
+		&Bundle{},
+		&BundleList{},
+	)
+	meta_v1.AddToGroupVersion(scheme, SchemeGroupVersion)
+
+	return nil
+}

--- a/pkg/apis/smith/v1/types.go
+++ b/pkg/apis/smith/v1/types.go
@@ -1,15 +1,16 @@
-package smith
+package v1
 
 import (
 	"bytes"
 	"fmt"
 	"reflect"
 
+	"github.com/atlassian/smith"
+
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	unstructured_conversion "k8s.io/apimachinery/pkg/conversion/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/json"
 )
 
@@ -40,38 +41,17 @@ const (
 )
 
 const (
-	SmithDomain        = "smith.atlassian.com"
-	SmithResourceGroup = SmithDomain
-
 	BundleResourceSingular = "bundle"
 	BundleResourcePlural   = "bundles"
 	BundleResourceVersion  = "v1"
 	BundleResourceKind     = "Bundle"
 
-	BundleResourceGroupVersion = SmithResourceGroup + "/" + BundleResourceVersion
+	BundleResourceGroupVersion = GroupName + "/" + BundleResourceVersion
 
-	BundleResourceName = BundleResourcePlural + "." + SmithDomain
-	BundleNameLabel    = BundleResourceName + "/BundleName"
-
-	// See docs/design/managing-resources.md
-	CrFieldPathAnnotation  = SmithDomain + "/CrReadyWhenFieldPath"
-	CrFieldValueAnnotation = SmithDomain + "/CrReadyWhenFieldValue"
+	BundleResourceName = BundleResourcePlural + "." + GroupName
 )
 
-var GV = schema.GroupVersion{
-	Group:   SmithResourceGroup,
-	Version: BundleResourceVersion,
-}
-
-var BundleGVK = GV.WithKind(BundleResourceKind)
-
-func AddToScheme(scheme *runtime.Scheme) {
-	scheme.AddKnownTypes(GV,
-		&Bundle{},
-		&BundleList{},
-	)
-	meta_v1.AddToGroupVersion(scheme, GV)
-}
+var BundleGVK = SchemeGroupVersion.WithKind(BundleResourceKind)
 
 type BundleList struct {
 	meta_v1.TypeMeta `json:",inline"`
@@ -209,7 +189,7 @@ type Resource struct {
 
 // ToUnstructured returns Spec field as an Unstructured object.
 // It makes a copy if it is an Unstructured already.
-func (r *Resource) ToUnstructured(copy DeepCopy) (*unstructured.Unstructured, error) {
+func (r *Resource) ToUnstructured(copy smith.DeepCopy) (*unstructured.Unstructured, error) {
 	if _, ok := r.Spec.(*unstructured.Unstructured); ok {
 		uCopy, err := copy(r.Spec)
 		if err != nil {

--- a/pkg/apis/smith/v1/types_test.go
+++ b/pkg/apis/smith/v1/types_test.go
@@ -1,4 +1,4 @@
-package smith
+package v1
 
 import (
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/pkg/client/bundle.go
+++ b/pkg/client/bundle.go
@@ -3,7 +3,7 @@ package client
 import (
 	"time"
 
-	"github.com/atlassian/smith"
+	smith_v1 "github.com/atlassian/smith/pkg/apis/smith/v1"
 
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
@@ -15,17 +15,19 @@ import (
 	"k8s.io/client-go/tools/cache"
 )
 
-func BundleScheme() *runtime.Scheme {
+func BundleScheme() (*runtime.Scheme, error) {
 	scheme := runtime.NewScheme()
-	smith.AddToScheme(scheme)
+	if err := smith_v1.AddToScheme(scheme); err != nil {
+		return nil, err
+	}
 	scheme.AddUnversionedTypes(api_v1.SchemeGroupVersion, &meta_v1.Status{})
-	return scheme
+	return scheme, nil
 }
 
 func BundleClient(cfg *rest.Config, scheme *runtime.Scheme) (*rest.RESTClient, error) {
 	groupVersion := schema.GroupVersion{
-		Group:   smith.SmithResourceGroup,
-		Version: smith.BundleResourceVersion,
+		Group:   smith_v1.GroupName,
+		Version: smith_v1.BundleResourceVersion,
 	}
 
 	config := *cfg
@@ -39,8 +41,8 @@ func BundleClient(cfg *rest.Config, scheme *runtime.Scheme) (*rest.RESTClient, e
 
 func BundleInformer(bundleClient cache.Getter, namespace string, resyncPeriod time.Duration) cache.SharedIndexInformer {
 	return cache.NewSharedIndexInformer(
-		cache.NewListWatchFromClient(bundleClient, smith.BundleResourcePlural, namespace, fields.Everything()),
-		&smith.Bundle{},
+		cache.NewListWatchFromClient(bundleClient, smith_v1.BundleResourcePlural, namespace, fields.Everything()),
+		&smith_v1.Bundle{},
 		resyncPeriod,
 		cache.Indexers{})
 }

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/atlassian/smith"
+	smith_v1 "github.com/atlassian/smith/pkg/apis/smith/v1"
 
 	"github.com/ash2k/stager/wait"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -105,7 +106,7 @@ func (c *BundleController) Run(ctx context.Context) {
 	<-ctx.Done()
 }
 
-func (c *BundleController) enqueue(bundle *smith.Bundle) {
+func (c *BundleController) enqueue(bundle *smith_v1.Bundle) {
 	key, err := cache.MetaNamespaceKeyFunc(bundle)
 	if err != nil {
 		log.Printf("Couldn't get key for Bundle %+v: %v", bundle, err)

--- a/pkg/controller/controller_bundle_event_handler.go
+++ b/pkg/controller/controller_bundle_event_handler.go
@@ -3,26 +3,26 @@ package controller
 import (
 	"log"
 
-	"github.com/atlassian/smith"
+	smith_v1 "github.com/atlassian/smith/pkg/apis/smith/v1"
 
 	"k8s.io/client-go/tools/cache"
 )
 
 func (c *BundleController) onBundleAdd(obj interface{}) {
-	bundle := obj.(*smith.Bundle)
+	bundle := obj.(*smith_v1.Bundle)
 	log.Printf("[%s/%s] Rebuilding bundle because it was added", bundle.Namespace, bundle.Name)
 	c.enqueue(bundle)
 
 }
 
 func (c *BundleController) onBundleUpdate(oldObj, newObj interface{}) {
-	bundle := newObj.(*smith.Bundle)
+	bundle := newObj.(*smith_v1.Bundle)
 	log.Printf("[%s/%s] Rebuilding bundle because it was updated", bundle.Namespace, bundle.Name)
 	c.enqueue(bundle)
 }
 
 func (c *BundleController) onBundleDelete(obj interface{}) {
-	bundle, ok := obj.(*smith.Bundle)
+	bundle, ok := obj.(*smith_v1.Bundle)
 	if !ok {
 		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
 		if !ok {

--- a/pkg/controller/controller_crd_event_handler.go
+++ b/pkg/controller/controller_crd_event_handler.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"log"
 
-	"github.com/atlassian/smith"
+	smith_v1 "github.com/atlassian/smith/pkg/apis/smith/v1"
 	"github.com/atlassian/smith/pkg/resources"
 
 	apiext_v1b1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
@@ -71,7 +71,7 @@ func (h *crdEventHandler) OnDelete(obj interface{}) {
 }
 
 func (h *crdEventHandler) ensureWatch(crd *apiext_v1b1.CustomResourceDefinition) bool {
-	if crd.Name == smith.BundleResourceName {
+	if crd.Name == smith_v1.BundleResourceName {
 		return false
 	}
 	if _, ok := h.watchers[crd.Name]; ok {

--- a/pkg/controller/controller_resource_event_handler.go
+++ b/pkg/controller/controller_resource_event_handler.go
@@ -3,7 +3,7 @@ package controller
 import (
 	"log"
 
-	"github.com/atlassian/smith"
+	smith_v1 "github.com/atlassian/smith/pkg/apis/smith/v1"
 	"github.com/atlassian/smith/pkg/resources"
 
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -64,7 +64,7 @@ func (c *BundleController) rebuildByName(namespace, bundleName, addUpdateDelete 
 	// TODO print GVK
 	log.Printf("[REH][%s/%s] Rebuilding bundle because object %s was %s",
 		namespace, bundleName, obj.(meta_v1.Object).GetName(), addUpdateDelete)
-	c.enqueue(&smith.Bundle{
+	c.enqueue(&smith_v1.Bundle{
 		ObjectMeta: meta_v1.ObjectMeta{
 			Name:      bundleName,
 			Namespace: namespace,
@@ -76,7 +76,7 @@ func getBundleNameAndNamespace(obj interface{}) (string, string) {
 	var bundleName string
 	meta := obj.(meta_v1.Object)
 	ref := resources.GetControllerOf(meta)
-	if ref != nil && ref.APIVersion == smith.BundleResourceGroupVersion && ref.Kind == smith.BundleResourceKind {
+	if ref != nil && ref.APIVersion == smith_v1.BundleResourceGroupVersion && ref.Kind == smith_v1.BundleResourceKind {
 		bundleName = ref.Name
 	}
 	return bundleName, meta.GetNamespace()

--- a/pkg/controller/controller_worker_test.go
+++ b/pkg/controller/controller_worker_test.go
@@ -3,7 +3,7 @@ package controller
 import (
 	"testing"
 
-	"github.com/atlassian/smith"
+	smith_v1 "github.com/atlassian/smith/pkg/apis/smith/v1"
 	"github.com/atlassian/smith/pkg/util/graph"
 
 	"github.com/stretchr/testify/assert"
@@ -12,23 +12,23 @@ import (
 
 func TestBundleSort(t *testing.T) {
 	t.Parallel()
-	bundle := smith.Bundle{
-		Spec: smith.BundleSpec{
-			Resources: []smith.Resource{
+	bundle := smith_v1.Bundle{
+		Spec: smith_v1.BundleSpec{
+			Resources: []smith_v1.Resource{
 				{
 					Name:      "a",
-					DependsOn: []smith.ResourceName{"c"},
+					DependsOn: []smith_v1.ResourceName{"c"},
 				},
 				{
 					Name: "b",
 				},
 				{
 					Name:      "c",
-					DependsOn: []smith.ResourceName{"b"},
+					DependsOn: []smith_v1.ResourceName{"b"},
 				},
 				{
 					Name:      "d",
-					DependsOn: []smith.ResourceName{"e"},
+					DependsOn: []smith_v1.ResourceName{"e"},
 				},
 				{
 					Name: "e",
@@ -39,28 +39,28 @@ func TestBundleSort(t *testing.T) {
 	_, sorted, err := sortBundle(&bundle)
 	require.NoError(t, err)
 
-	assert.EqualValues(t, []graph.V{smith.ResourceName("b"), smith.ResourceName("c"), smith.ResourceName("a"), smith.ResourceName("e"), smith.ResourceName("d")}, sorted)
+	assert.EqualValues(t, []graph.V{smith_v1.ResourceName("b"), smith_v1.ResourceName("c"), smith_v1.ResourceName("a"), smith_v1.ResourceName("e"), smith_v1.ResourceName("d")}, sorted)
 }
 
 func TestBundleSortMissingDependency(t *testing.T) {
 	t.Parallel()
-	bundle := smith.Bundle{
-		Spec: smith.BundleSpec{
-			Resources: []smith.Resource{
+	bundle := smith_v1.Bundle{
+		Spec: smith_v1.BundleSpec{
+			Resources: []smith_v1.Resource{
 				{
 					Name:      "a",
-					DependsOn: []smith.ResourceName{"x"},
+					DependsOn: []smith_v1.ResourceName{"x"},
 				},
 				{
 					Name: "b",
 				},
 				{
 					Name:      "c",
-					DependsOn: []smith.ResourceName{"b"},
+					DependsOn: []smith_v1.ResourceName{"b"},
 				},
 				{
 					Name:      "d",
-					DependsOn: []smith.ResourceName{"e"},
+					DependsOn: []smith_v1.ResourceName{"e"},
 				},
 				{
 					Name: "e",

--- a/pkg/controller/spec_processor.go
+++ b/pkg/controller/spec_processor.go
@@ -7,7 +7,7 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/atlassian/smith"
+	smith_v1 "github.com/atlassian/smith/pkg/apis/smith/v1"
 	"github.com/atlassian/smith/pkg/resources"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -25,13 +25,13 @@ var (
 )
 
 type SpecProcessor struct {
-	selfName         smith.ResourceName
-	readyResources   map[smith.ResourceName]*unstructured.Unstructured
-	allowedResources map[smith.ResourceName]struct{}
+	selfName         smith_v1.ResourceName
+	readyResources   map[smith_v1.ResourceName]*unstructured.Unstructured
+	allowedResources map[smith_v1.ResourceName]struct{}
 }
 
-func NewSpec(selfName smith.ResourceName, readyResources map[smith.ResourceName]*unstructured.Unstructured, allowedResources []smith.ResourceName) *SpecProcessor {
-	ar := make(map[smith.ResourceName]struct{}, len(allowedResources))
+func NewSpec(selfName smith_v1.ResourceName, readyResources map[smith_v1.ResourceName]*unstructured.Unstructured, allowedResources []smith_v1.ResourceName) *SpecProcessor {
+	ar := make(map[smith_v1.ResourceName]struct{}, len(allowedResources))
 	for _, allowedResource := range allowedResources {
 		ar[allowedResource] = struct{}{}
 	}
@@ -113,7 +113,7 @@ func (sp *SpecProcessor) processMatch(selector string, primitivesOnly bool) (int
 	if len(parts) < 2 {
 		return nil, fmt.Errorf("cannot include whole object: %s", selector)
 	}
-	objName := smith.ResourceName(parts[0])
+	objName := smith_v1.ResourceName(parts[0])
 	if objName == sp.selfName {
 		return nil, fmt.Errorf("self references are not allowed: %s", selector)
 	}

--- a/pkg/controller/spec_processor_test.go
+++ b/pkg/controller/spec_processor_test.go
@@ -4,7 +4,7 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/atlassian/smith"
+	smith_v1 "github.com/atlassian/smith/pkg/apis/smith/v1"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -16,7 +16,7 @@ func TestSpecProcessor(t *testing.T) {
 	sp := SpecProcessor{
 		selfName:       "abc",
 		readyResources: readyResources(),
-		allowedResources: map[smith.ResourceName]struct{}{
+		allowedResources: map[smith_v1.ResourceName]struct{}{
 			"res1": {},
 		},
 	}
@@ -202,7 +202,7 @@ func TestSpecProcessorErrors(t *testing.T) {
 			sp := SpecProcessor{
 				selfName:       "self1",
 				readyResources: readyResources(),
-				allowedResources: map[smith.ResourceName]struct{}{
+				allowedResources: map[smith_v1.ResourceName]struct{}{
 					"res1": {},
 				},
 			}
@@ -211,8 +211,8 @@ func TestSpecProcessorErrors(t *testing.T) {
 	}
 }
 
-func readyResources() map[smith.ResourceName]*unstructured.Unstructured {
-	return map[smith.ResourceName]*unstructured.Unstructured{
+func readyResources() map[smith_v1.ResourceName]*unstructured.Unstructured {
+	return map[smith_v1.ResourceName]*unstructured.Unstructured{
 		"res1": {
 			Object: map[string]interface{}{
 				"a": map[string]interface{}{

--- a/pkg/controller/types.go
+++ b/pkg/controller/types.go
@@ -2,6 +2,7 @@ package controller
 
 import (
 	"github.com/atlassian/smith"
+	smith_v1 "github.com/atlassian/smith/pkg/apis/smith/v1"
 
 	apiext_v1b1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -27,9 +28,9 @@ type Store interface {
 
 type BundleStore interface {
 	// Get returns Bundle based on its namespace and name.
-	Get(namespace, bundleName string) (*smith.Bundle, error)
+	Get(namespace, bundleName string) (*smith_v1.Bundle, error)
 	// GetBundlesByCrd returns Bundles which have a resource defined by CRD.
-	GetBundlesByCrd(*apiext_v1b1.CustomResourceDefinition) ([]*smith.Bundle, error)
+	GetBundlesByCrd(*apiext_v1b1.CustomResourceDefinition) ([]*smith_v1.Bundle, error)
 	// GetBundlesByObject returns Bundles which have a resource of a particular group/kind with a name in a namespace.
-	GetBundlesByObject(gk schema.GroupKind, namespace, name string) ([]*smith.Bundle, error)
+	GetBundlesByObject(gk schema.GroupKind, namespace, name string) ([]*smith_v1.Bundle, error)
 }

--- a/pkg/resources/crd_helpers.go
+++ b/pkg/resources/crd_helpers.go
@@ -6,7 +6,7 @@ import (
 	"log"
 	"time"
 
-	"github.com/atlassian/smith"
+	smith_v1 "github.com/atlassian/smith/pkg/apis/smith/v1"
 	"github.com/atlassian/smith/pkg/util"
 
 	apiext_v1b1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
@@ -21,15 +21,15 @@ import (
 func BundleCrd() *apiext_v1b1.CustomResourceDefinition {
 	return &apiext_v1b1.CustomResourceDefinition{
 		ObjectMeta: meta_v1.ObjectMeta{
-			Name: smith.BundleResourceName,
+			Name: smith_v1.BundleResourceName,
 		},
 		Spec: apiext_v1b1.CustomResourceDefinitionSpec{
-			Group:   smith.SmithResourceGroup,
-			Version: smith.BundleResourceVersion,
+			Group:   smith_v1.GroupName,
+			Version: smith_v1.BundleResourceVersion,
 			Names: apiext_v1b1.CustomResourceDefinitionNames{
-				Plural:   smith.BundleResourcePlural,
-				Singular: smith.BundleResourceSingular,
-				Kind:     smith.BundleResourceKind,
+				Plural:   smith_v1.BundleResourcePlural,
+				Singular: smith_v1.BundleResourceSingular,
+				Kind:     smith_v1.BundleResourceKind,
 			},
 		},
 	}

--- a/pkg/resources/objects_test.go
+++ b/pkg/resources/objects_test.go
@@ -3,7 +3,7 @@ package resources
 import (
 	"testing"
 
-	"github.com/atlassian/smith"
+	smith_v1 "github.com/atlassian/smith/pkg/apis/smith/v1"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -12,20 +12,20 @@ import (
 
 func TestGetJsonPathStringBundle(t *testing.T) {
 	t.Parallel()
-	b := &smith.Bundle{
-		Status: smith.BundleStatus{
-			Conditions: []smith.BundleCondition{
+	b := &smith_v1.Bundle{
+		Status: smith_v1.BundleStatus{
+			Conditions: []smith_v1.BundleCondition{
 				{
-					Type:   smith.BundleError,
-					Status: smith.ConditionFalse,
+					Type:   smith_v1.BundleError,
+					Status: smith_v1.ConditionFalse,
 				},
 				{
-					Type:   smith.BundleReady,
-					Status: smith.ConditionTrue,
+					Type:   smith_v1.BundleReady,
+					Status: smith_v1.ConditionTrue,
 				},
 				{
-					Type:   smith.BundleInProgress,
-					Status: smith.ConditionFalse,
+					Type:   smith_v1.BundleInProgress,
+					Status: smith_v1.ConditionFalse,
 				},
 			},
 		},
@@ -37,13 +37,13 @@ func TestGetJsonPathStringBundle(t *testing.T) {
 	require.NoError(t, err)
 	status, err := GetJsonPathString(unstructured, `{$.status.conditions[?(@.type=="Ready")].status}`)
 	require.NoError(t, err)
-	assert.Equal(t, string(smith.ConditionTrue), status)
+	assert.Equal(t, string(smith_v1.ConditionTrue), status)
 }
 
 func TestGetJsonPathStringMissing(t *testing.T) {
 	t.Parallel()
 	// Bundle with empty status
-	b := &smith.Bundle{}
+	b := &smith_v1.Bundle{}
 	bytes, err := json.Marshal(b)
 	require.NoError(t, err)
 	unstructured := make(map[string]interface{})
@@ -57,12 +57,12 @@ func TestGetJsonPathStringMissing(t *testing.T) {
 
 func TestGetJsonPathStringInvalid(t *testing.T) {
 	t.Parallel()
-	b := &smith.Bundle{
-		Status: smith.BundleStatus{
-			Conditions: []smith.BundleCondition{
+	b := &smith_v1.Bundle{
+		Status: smith_v1.BundleStatus{
+			Conditions: []smith_v1.BundleCondition{
 				{
-					Type:   smith.BundleReady,
-					Status: smith.ConditionTrue,
+					Type:   smith_v1.BundleReady,
+					Status: smith_v1.ConditionTrue,
 				},
 			},
 		},

--- a/pkg/store/bundle.go
+++ b/pkg/store/bundle.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/atlassian/smith"
+	smith_v1 "github.com/atlassian/smith/pkg/apis/smith/v1"
 
 	apiext_v1b1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -40,42 +41,42 @@ func NewBundle(bundleInf cache.SharedIndexInformer, store smith.ByNameStore, dee
 
 // Get returns a bundle by its namespace and name.
 // nil is returned if bundle does not exist.
-func (s *BundleStore) Get(namespace, bundleName string) (*smith.Bundle, error) {
-	bundle, exists, err := s.store.Get(smith.BundleGVK, namespace, bundleName)
+func (s *BundleStore) Get(namespace, bundleName string) (*smith_v1.Bundle, error) {
+	bundle, exists, err := s.store.Get(smith_v1.BundleGVK, namespace, bundleName)
 	if err != nil || !exists {
 		return nil, err
 	}
-	return bundle.(*smith.Bundle), nil
+	return bundle.(*smith_v1.Bundle), nil
 }
 
 // GetBundlesByCrd returns Bundles which have a resource defined by CRD.
-func (s *BundleStore) GetBundlesByCrd(crd *apiext_v1b1.CustomResourceDefinition) ([]*smith.Bundle, error) {
+func (s *BundleStore) GetBundlesByCrd(crd *apiext_v1b1.CustomResourceDefinition) ([]*smith_v1.Bundle, error) {
 	return s.getBundles(byCrdGroupKindIndexName, byCrdGroupKindIndexKey(crd.Spec.Group, crd.Spec.Names.Kind))
 }
 
 // GetBundlesByObject returns bundles where a resource with specified GVK, namespace and name is defined.
-func (s *BundleStore) GetBundlesByObject(gk schema.GroupKind, namespace, name string) ([]*smith.Bundle, error) {
+func (s *BundleStore) GetBundlesByObject(gk schema.GroupKind, namespace, name string) ([]*smith_v1.Bundle, error) {
 	return s.getBundles(byObjectIndexName, byObjectIndexKey(gk, namespace, name))
 }
 
-func (s *BundleStore) getBundles(indexName, indexKey string) ([]*smith.Bundle, error) {
+func (s *BundleStore) getBundles(indexName, indexKey string) ([]*smith_v1.Bundle, error) {
 	bundles, err := s.bundleByIndex(indexName, indexKey)
 	if err != nil {
 		return nil, err
 	}
-	result := make([]*smith.Bundle, 0, len(bundles))
+	result := make([]*smith_v1.Bundle, 0, len(bundles))
 	for _, bundle := range bundles {
 		b, err := s.deepCopy(bundle)
 		if err != nil {
 			return nil, fmt.Errorf("failed to deep copy %T: %v", bundle, err)
 		}
-		result = append(result, b.(*smith.Bundle))
+		result = append(result, b.(*smith_v1.Bundle))
 	}
 	return result, nil
 }
 
 func byCrdGroupKindIndex(obj interface{}) ([]string, error) {
-	bundle := obj.(*smith.Bundle)
+	bundle := obj.(*smith_v1.Bundle)
 	var result []string
 	for _, resource := range bundle.Spec.Resources {
 		gvk := resource.Spec.GetObjectKind().GroupVersionKind()
@@ -94,7 +95,7 @@ func byCrdGroupKindIndexKey(group, kind string) string {
 }
 
 func byObjectIndex(obj interface{}) ([]string, error) {
-	bundle := obj.(*smith.Bundle)
+	bundle := obj.(*smith_v1.Bundle)
 	result := make([]string, 0, len(bundle.Spec.Resources))
 	for _, resource := range bundle.Spec.Resources {
 		m := resource.Spec.(meta_v1.Object)

--- a/pkg/store/multi.go
+++ b/pkg/store/multi.go
@@ -5,6 +5,7 @@ import (
 	"sync"
 
 	"github.com/atlassian/smith"
+	smith_v1 "github.com/atlassian/smith/pkg/apis/smith/v1"
 	"github.com/atlassian/smith/pkg/resources"
 
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -126,7 +127,7 @@ func byNamespaceAndBundleNameIndex(obj interface{}) ([]string, error) {
 	}
 	m := obj.(meta_v1.Object)
 	ref := resources.GetControllerOf(m)
-	if ref != nil && ref.APIVersion == smith.BundleResourceGroupVersion && ref.Kind == smith.BundleResourceKind {
+	if ref != nil && ref.APIVersion == smith_v1.BundleResourceGroupVersion && ref.Kind == smith_v1.BundleResourceKind {
 		return []string{ByNamespaceAndBundleNameIndexKey(m.GetNamespace(), ref.Name)}, nil
 	}
 	return nil, nil


### PR DESCRIPTION
This is necessary for Kubernetes code generation tools.
Updates #106 and #107.