### PR TITLE
Update rules

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,4 +1,3 @@
-build --verbose_failures
 build --workspace_status_command build/print-workspace-status.sh
 
 test --features=race

--- a/Makefile
+++ b/Makefile
@@ -135,6 +135,6 @@ docker-export:
 	bazel run --cpu=k8 //cmd/smith:container
 
 release: update-bazel
-	bazel run --cpu=k8 //cmd/smith:push-container
+	bazel run --cpu=k8 //cmd/smith:push-docker
 
 .PHONY: build

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ update-bazel:
 build: fmt update-bazel build-ci
 
 build-race: fmt update-bazel
-	bazel build //cmd/smith:smith-race
+	bazel build //cmd/smith --output_groups=race
 
 build-ci:
 	bazel build //cmd/smith
@@ -73,7 +73,7 @@ minikube-test-sc: fmt update-bazel
 		--test_env=SERVICE_CATALOG_URL="http://$$(minikube ip):30080" \
 		//it/sc:go_default_test
 
-minikube-run: fmt update-bazel
+minikube-run: fmt update-bazel build-race
 	KUBE_PATCH_CONVERSION_DETECTOR=true \
 	KUBE_CACHE_MUTATION_DETECTOR=true \
 	KUBERNETES_SERVICE_HOST="$$(minikube ip)" \
@@ -81,9 +81,9 @@ minikube-run: fmt update-bazel
 	KUBERNETES_CA_PATH="$$HOME/.minikube/ca.crt" \
 	KUBERNETES_CLIENT_CERT="$$HOME/.minikube/apiserver.crt" \
 	KUBERNETES_CLIENT_KEY="$$HOME/.minikube/apiserver.key" \
-	bazel run //cmd/smith:smith-race -- -disable-service-catalog
+	bazel-bin/cmd/smith/smith.race -disable-service-catalog
 
-minikube-run-sc: fmt update-bazel
+minikube-run-sc: fmt update-bazel build-race
 	KUBE_PATCH_CONVERSION_DETECTOR=true \
 	KUBE_CACHE_MUTATION_DETECTOR=true \
 	KUBERNETES_SERVICE_HOST="$$(minikube ip)" \
@@ -91,11 +91,12 @@ minikube-run-sc: fmt update-bazel
 	KUBERNETES_CA_PATH="$$HOME/.minikube/ca.crt" \
 	KUBERNETES_CLIENT_CERT="$$HOME/.minikube/apiserver.crt" \
 	KUBERNETES_CLIENT_KEY="$$HOME/.minikube/apiserver.key" \
-	bazel run //cmd/smith:smith-race -- \
+	bazel-bin/cmd/smith/smith.race  \
 	-service-catalog-url="https://$$(minikube ip):30443" \
 	-service-catalog-insecure
 
 minikube-sleeper-run: fmt update-bazel
+	bazel build //examples/sleeper/main --output_groups=race
 	KUBE_PATCH_CONVERSION_DETECTOR=true \
 	KUBE_CACHE_MUTATION_DETECTOR=true \
 	KUBERNETES_SERVICE_HOST="$$(minikube ip)" \
@@ -103,7 +104,7 @@ minikube-sleeper-run: fmt update-bazel
 	KUBERNETES_CA_PATH="$$HOME/.minikube/ca.crt" \
 	KUBERNETES_CLIENT_CERT="$$HOME/.minikube/apiserver.crt" \
 	KUBERNETES_CLIENT_KEY="$$HOME/.minikube/apiserver.key" \
-	bazel run //examples/sleeper/main:main-race
+	bazel-bin/examples/sleeper/main/main.race
 
 test: fmt update-bazel test-ci
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,13 +1,12 @@
 git_repository(
     name = "io_bazel_rules_go",
     remote = "https://github.com/bazelbuild/rules_go.git",
-    commit = "a280fbac1a0a4c67b0eee660b4fd1b3db7c9f058",
+    commit = "bcc7a4ff5a21ff2640f86cb302a7d976e33d89f1",
 )
 git_repository(
     name = "io_bazel_rules_docker",
     remote = "https://github.com/bazelbuild/rules_docker.git",
-    commit = "9dd92c73e7c8cf07ad5e0dca89a3c3c422a3ab7d",
-#    tag = "v0.3.0",
+    commit = "58d022892232e5d59daba7760289976d5f6e7433",
 )
 
 load("@io_bazel_rules_go//go:def.bzl", "go_rules_dependencies", "go_register_toolchains")

--- a/cmd/smith/BUILD.bazel
+++ b/cmd/smith/BUILD.bazel
@@ -24,14 +24,6 @@ go_binary(
     visibility = ["//visibility:public"],
 )
 
-go_binary(
-    name = "smith-race",
-    gc_linkopts = ["-race"],
-    importpath = "github.com/atlassian/smith/cmd/smith",
-    library = ":go_default_library",
-    visibility = ["//visibility:public"],
-)
-
 container_image(
     name = "container",
     base = "@distroless_base//image",

--- a/cmd/smith/BUILD.bazel
+++ b/cmd/smith/BUILD.bazel
@@ -32,7 +32,7 @@ container_image(
 )
 
 container_push(
-    name = "push-container",
+    name = "push-docker",
     format = "Docker",
     image = ":container",
     registry = "index.docker.io",

--- a/examples/sleeper/main/BUILD.bazel
+++ b/examples/sleeper/main/BUILD.bazel
@@ -13,14 +13,6 @@ go_library(
 )
 
 go_binary(
-    name = "main-race",
-    gc_linkopts = ["-race"],
-    importpath = "github.com/atlassian/smith/examples/sleeper/main",
-    library = ":go_default_library",
-    visibility = ["//visibility:public"],
-)
-
-go_binary(
     name = "main",
     importpath = "github.com/atlassian/smith/examples/sleeper/main",
     library = ":go_default_library",

--- a/pkg/plugin/BUILD.bazel
+++ b/pkg/plugin/BUILD.bazel
@@ -1,0 +1,12 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["types.go"],
+    importpath = "github.com/atlassian/smith/pkg/plugin",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/apis/smith/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
+    ],
+)

--- a/pkg/resources/crd_helpers.go
+++ b/pkg/resources/crd_helpers.go
@@ -40,7 +40,7 @@ func EnsureCrdExistsAndIsEstablished(ctx context.Context, scheme *runtime.Scheme
 	if err != nil {
 		return err
 	}
-	log.Printf("Waiting for CustomResourceDefinition %s it to become established", crd.Name)
+	log.Printf("Waiting for CustomResourceDefinition %s to become established", crd.Name)
 	return WaitForCrdToBecomeEstablished(ctx, crdLister, crd)
 }
 


### PR DESCRIPTION
Fixes #147. It seems the issue was caused by `gc_linkopts = ["-race"]`. My guess is that standard library was not compiled properly for `-race` to work. Using an output group fixes that.