### PR TITLE
Use go_image rule to remove boilerplate

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -6,22 +6,14 @@ git_repository(
 git_repository(
     name = "io_bazel_rules_docker",
     remote = "https://github.com/bazelbuild/rules_docker.git",
-    commit = "04165ef6de8e12975740238445cad6a623e6de2f",
+    commit = "cce1de49c54b145a9d9542685660f72d8fa593a7",
 )
 
 load("@io_bazel_rules_go//go:def.bzl", "go_rules_dependencies", "go_register_toolchains")
-load("@io_bazel_rules_docker//container:container.bzl", "container_pull", container_repositories = "repositories")
 
 go_rules_dependencies()
 go_register_toolchains()
 
-container_repositories()
+load("@io_bazel_rules_docker//go:image.bzl", go_image_repositories = "repositories")
 
-# https://github.com/GoogleCloudPlatform/distroless/blob/master/base/README.md
-container_pull(
-    name = "distroless_base",
-    digest = "sha256:bef8d030c7f36dfb73a8c76137616faeea73ac5a8495d535f27c911d0db77af3",
-    registry = "gcr.io",
-    repository = "distroless/base",
-    #tag = "latest",  # ignored, but kept here for documentation
-)
+go_image_repositories()

--- a/cmd/smith/BUILD.bazel
+++ b/cmd/smith/BUILD.bazel
@@ -1,5 +1,6 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 load("@io_bazel_rules_docker//container:container.bzl", "container_image", "container_push")
+load("@io_bazel_rules_docker//go:image.bzl", "go_image")
 
 go_library(
     name = "go_default_library",
@@ -24,13 +25,9 @@ go_binary(
     visibility = ["//visibility:public"],
 )
 
-container_image(
+go_image(
     name = "container",
-    base = "@distroless_base//image",
-    entrypoint = ["/smith"],
-    files = [
-        ":smith",
-    ],
+    binary = ":smith",
 )
 
 container_push(


### PR DESCRIPTION
Ref #165. @mattmoor, hey this is cool! I like to have logically distinct things to be separate. Easier to understand it that way. Too much magic inside of a single rule is confusing.