### PR TITLE
Remove extra unnecessary version check

### DIFF
--- a/pkg/cleanup/object_cleanup.go
+++ b/pkg/cleanup/object_cleanup.go
@@ -30,12 +30,7 @@ func New(kts ...map[schema.GroupKind]SpecCleanup) *SpecCleaner {
 }
 
 func (oc *SpecCleaner) Cleanup(spec, actual *unstructured.Unstructured) (updatedSpec *unstructured.Unstructured, err error) {
-	gvk := spec.GroupVersionKind()
-	gk := gvk.GroupKind()
-
-	if gk.Kind == "" || gvk.Version == "" { // Group can be empty e.g. built-in objects like ConfigMap
-		return nil, errors.Errorf("object has empty kind/version: %s", gvk)
-	}
+	gk := spec.GroupVersionKind().GroupKind()
 
 	if objCleanup, ok := oc.KnownTypes[gk]; ok {
 		return objCleanup(spec, actual)


### PR DESCRIPTION
This is dead code from previous test failure cleanups. Mikhail suggests he added it in the pass during debugging and it no longer needs to exist.