### PR TITLE
Support loading configuration from a file

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -128,6 +128,18 @@
   revision = "0a025b7e63adc15a622f29b0b2c4c3848243bbf6"
 
 [[projects]]
+  branch = "master"
+  name = "github.com/howeyc/gopass"
+  packages = ["."]
+  revision = "bf9dde6d0d2c004a008c27aaee91170c786f6db8"
+
+[[projects]]
+  name = "github.com/imdario/mergo"
+  packages = ["."]
+  revision = "7fe0c75c13abdee74b09fcacef5ea1c6bba6a874"
+  version = "0.2.4"
+
+[[projects]]
   name = "github.com/json-iterator/go"
   packages = ["."]
   revision = "f7279a603edee96fe7764d3de9c6ff8cf9970994"
@@ -214,7 +226,7 @@
 [[projects]]
   branch = "master"
   name = "golang.org/x/crypto"
-  packages = ["bcrypt","blowfish"]
+  packages = ["bcrypt","blowfish","ssh/terminal"]
   revision = "0fcca4842a8d74bfddc2c96a073bd2a4d2a7a2e8"
 
 [[projects]]
@@ -222,6 +234,12 @@
   name = "golang.org/x/net"
   packages = ["context","http2","http2/hpack","idna","lex/httplex"]
   revision = "d866cfc389cec985d6fda2859936a575a55a3ab6"
+
+[[projects]]
+  branch = "master"
+  name = "golang.org/x/sys"
+  packages = ["unix","windows"]
+  revision = "810d7000345868fc619eb81f46307107118f4ae1"
 
 [[projects]]
   branch = "master"
@@ -262,7 +280,7 @@
 [[projects]]
   branch = "release-5.0"
   name = "k8s.io/client-go"
-  packages = ["discovery","discovery/fake","dynamic","informers/apps/v1beta2","informers/core/v1","informers/extensions/v1beta1","informers/internalinterfaces","informers/settings/v1alpha1","kubernetes","kubernetes/fake","kubernetes/scheme","kubernetes/typed/admissionregistration/v1alpha1","kubernetes/typed/admissionregistration/v1alpha1/fake","kubernetes/typed/apps/v1beta1","kubernetes/typed/apps/v1beta1/fake","kubernetes/typed/apps/v1beta2","kubernetes/typed/apps/v1beta2/fake","kubernetes/typed/authentication/v1","kubernetes/typed/authentication/v1/fake","kubernetes/typed/authentication/v1beta1","kubernetes/typed/authentication/v1beta1/fake","kubernetes/typed/authorization/v1","kubernetes/typed/authorization/v1/fake","kubernetes/typed/authorization/v1beta1","kubernetes/typed/authorization/v1beta1/fake","kubernetes/typed/autoscaling/v1","kubernetes/typed/autoscaling/v1/fake","kubernetes/typed/autoscaling/v2beta1","kubernetes/typed/autoscaling/v2beta1/fake","kubernetes/typed/batch/v1","kubernetes/typed/batch/v1/fake","kubernetes/typed/batch/v1beta1","kubernetes/typed/batch/v1beta1/fake","kubernetes/typed/batch/v2alpha1","kubernetes/typed/batch/v2alpha1/fake","kubernetes/typed/certificates/v1beta1","kubernetes/typed/certificates/v1beta1/fake","kubernetes/typed/core/v1","kubernetes/typed/core/v1/fake","kubernetes/typed/extensions/v1beta1","kubernetes/typed/extensions/v1beta1/fake","kubernetes/typed/networking/v1","kubernetes/typed/networking/v1/fake","kubernetes/typed/policy/v1beta1","kubernetes/typed/policy/v1beta1/fake","kubernetes/typed/rbac/v1","kubernetes/typed/rbac/v1/fake","kubernetes/typed/rbac/v1alpha1","kubernetes/typed/rbac/v1alpha1/fake","kubernetes/typed/rbac/v1beta1","kubernetes/typed/rbac/v1beta1/fake","kubernetes/typed/scheduling/v1alpha1","kubernetes/typed/scheduling/v1alpha1/fake","kubernetes/typed/settings/v1alpha1","kubernetes/typed/settings/v1alpha1/fake","kubernetes/typed/storage/v1","kubernetes/typed/storage/v1/fake","kubernetes/typed/storage/v1beta1","kubernetes/typed/storage/v1beta1/fake","listers/apps/v1beta2","listers/core/v1","listers/extensions/v1beta1","listers/settings/v1alpha1","pkg/version","rest","rest/watch","testing","third_party/forked/golang/template","tools/cache","tools/clientcmd/api","tools/leaderelection","tools/leaderelection/resourcelock","tools/metrics","tools/pager","tools/record","tools/reference","transport","util/cert","util/flowcontrol","util/integer","util/jsonpath","util/workqueue"]
+  packages = ["discovery","discovery/fake","dynamic","informers/apps/v1beta2","informers/core/v1","informers/extensions/v1beta1","informers/internalinterfaces","informers/settings/v1alpha1","kubernetes","kubernetes/fake","kubernetes/scheme","kubernetes/typed/admissionregistration/v1alpha1","kubernetes/typed/admissionregistration/v1alpha1/fake","kubernetes/typed/apps/v1beta1","kubernetes/typed/apps/v1beta1/fake","kubernetes/typed/apps/v1beta2","kubernetes/typed/apps/v1beta2/fake","kubernetes/typed/authentication/v1","kubernetes/typed/authentication/v1/fake","kubernetes/typed/authentication/v1beta1","kubernetes/typed/authentication/v1beta1/fake","kubernetes/typed/authorization/v1","kubernetes/typed/authorization/v1/fake","kubernetes/typed/authorization/v1beta1","kubernetes/typed/authorization/v1beta1/fake","kubernetes/typed/autoscaling/v1","kubernetes/typed/autoscaling/v1/fake","kubernetes/typed/autoscaling/v2beta1","kubernetes/typed/autoscaling/v2beta1/fake","kubernetes/typed/batch/v1","kubernetes/typed/batch/v1/fake","kubernetes/typed/batch/v1beta1","kubernetes/typed/batch/v1beta1/fake","kubernetes/typed/batch/v2alpha1","kubernetes/typed/batch/v2alpha1/fake","kubernetes/typed/certificates/v1beta1","kubernetes/typed/certificates/v1beta1/fake","kubernetes/typed/core/v1","kubernetes/typed/core/v1/fake","kubernetes/typed/extensions/v1beta1","kubernetes/typed/extensions/v1beta1/fake","kubernetes/typed/networking/v1","kubernetes/typed/networking/v1/fake","kubernetes/typed/policy/v1beta1","kubernetes/typed/policy/v1beta1/fake","kubernetes/typed/rbac/v1","kubernetes/typed/rbac/v1/fake","kubernetes/typed/rbac/v1alpha1","kubernetes/typed/rbac/v1alpha1/fake","kubernetes/typed/rbac/v1beta1","kubernetes/typed/rbac/v1beta1/fake","kubernetes/typed/scheduling/v1alpha1","kubernetes/typed/scheduling/v1alpha1/fake","kubernetes/typed/settings/v1alpha1","kubernetes/typed/settings/v1alpha1/fake","kubernetes/typed/storage/v1","kubernetes/typed/storage/v1/fake","kubernetes/typed/storage/v1beta1","kubernetes/typed/storage/v1beta1/fake","listers/apps/v1beta2","listers/core/v1","listers/extensions/v1beta1","listers/settings/v1alpha1","pkg/version","rest","rest/watch","testing","third_party/forked/golang/template","tools/auth","tools/cache","tools/clientcmd","tools/clientcmd/api","tools/clientcmd/api/latest","tools/clientcmd/api/v1","tools/leaderelection","tools/leaderelection/resourcelock","tools/metrics","tools/pager","tools/record","tools/reference","transport","util/cert","util/flowcontrol","util/homedir","util/integer","util/jsonpath","util/workqueue"]
   revision = "3a46b5de730a74e064197a157c96c2d29724a677"
 
 [[projects]]
@@ -285,6 +303,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "acd8498f0bf4823e2368fad18909af9fae6184aea7c6b5487225b5bed1e734c4"
+  inputs-digest = "3c48e7bd99d81750bc658a37e53a900c3f668eb3bfa56e6fef06927f869c9773"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/examples/sleeper/main/main.go
+++ b/examples/sleeper/main/main.go
@@ -15,7 +15,6 @@ import (
 )
 
 func main() {
-	flag.Parse()
 	if err := run(); err != nil && err != context.Canceled && err != context.DeadlineExceeded {
 		log.Fatalln(err)
 	}
@@ -30,12 +29,18 @@ func run() error {
 }
 
 func runWithContext(ctx context.Context) error {
-	config, err := client.ConfigFromEnv()
+	configFileFrom := flag.String("client-config-from", "in-cluster",
+		"Source of REST client configuration. 'in-cluster' (default), 'environment' and 'file' are valid options.")
+	configFileName := flag.String("client-config-file-name", "",
+		"Load REST client configuration from the specified Kubernetes config file. This is only applicable if --client-config-from=file is set.")
+	configContext := flag.String("client-config-context", "",
+		"Context to use for REST client configuration. This is only applicable if --client-config-from=file is set.")
+
+	flag.Parse()
+
+	config, err := client.LoadConfig(*configFileFrom, *configFileName, *configContext)
 	if err != nil {
-		config, err = rest.InClusterConfig()
-		if err != nil {
-			return err
-		}
+		return err
 	}
 	config.UserAgent = "sleeper-controller"
 

--- a/it/utils_for_tests.go
+++ b/it/utils_for_tests.go
@@ -121,7 +121,11 @@ func IsBundleNewerCond(namespace, name string, resourceVersions ...string) watch
 }
 
 func TestSetup(t *testing.T) (*rest.Config, *kubernetes.Clientset, *smithClientset.Clientset) {
-	config, err := client.ConfigFromEnv()
+	configFileFrom := os.Getenv("KUBERNETES_CONFIG_FROM")
+	configFileName := os.Getenv("KUBERNETES_CONFIG_FILENAME")
+	configContext := os.Getenv("KUBERNETES_CONFIG_CONTEXT")
+
+	config, err := client.LoadConfig(configFileFrom, configFileName, configContext)
 	require.NoError(t, err)
 
 	clientset, err := kubernetes.NewForConfig(config)

--- a/pkg/client/BUILD.bazel
+++ b/pkg/client/BUILD.bazel
@@ -17,5 +17,7 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/watch:go_default_library",
         "//vendor/k8s.io/client-go/rest:go_default_library",
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",
+        "//vendor/k8s.io/client-go/tools/clientcmd:go_default_library",
+        "//vendor/k8s.io/client-go/tools/clientcmd/api:go_default_library",
     ],
 )

--- a/pkg/client/config.go
+++ b/pkg/client/config.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/pkg/errors"
 	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 )
 
 func ConfigFromEnv() (*rest.Config, error) {
@@ -25,4 +27,31 @@ func ConfigFromEnv() (*rest.Config, error) {
 			KeyFile:  KeyFile,
 		},
 	}, nil
+}
+
+func LoadConfig(configFileFrom, configFileName, configContext string) (*rest.Config, error) {
+	var config *rest.Config
+	var err error
+
+	switch configFileFrom {
+	case "in-cluster":
+		config, err = rest.InClusterConfig()
+	case "environment":
+		config, err = ConfigFromEnv()
+	case "file":
+		var configApi *clientcmdapi.Config
+		configApi, err = clientcmd.LoadFromFile(configFileName)
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to load REST client configuration from file %q", configFileName)
+		}
+		config, err = clientcmd.NewDefaultClientConfig(*configApi, &clientcmd.ConfigOverrides{
+			CurrentContext: configContext,
+		}).ClientConfig()
+	default:
+		err = errors.New("invalid value for 'client config from' parameter")
+	}
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to load REST client configuration from %q", configFileFrom)
+	}
+	return config, nil
 }


### PR DESCRIPTION
This is useful to be able to pick up any cluster configuration in any form kubectl supports.
In practice I did this to see if Docker's built-in Kubernetes support works with our integration tests. It does.
See https://docs.docker.com/docker-for-mac/kubernetes/

I've left a few make targets with references to minikbe. That is because I haven't figured out yet if Service Catalog works on Kube-on-Docker and if aggregation layer is enabled there (it should, it is on by default in 1.8).