### PR TITLE
Travis build cleanups

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ cache:
     - $GOPATH/pkg/dep
 
 go:
-  - 1.9.2
+  - 1.9.3
 
 os:
   - linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,23 +13,27 @@ os:
 env:
   global:
     - CHANGE_MINIKUBE_NONE_USER=true
+    - DEP_VERSION=v0.4.1
+    - BAZEL_VERSION=0.9.0
+    - KUBECTL_VERSION=v1.9.2
     # DOCKER_USERNAME and DOCKER_PASSWORD
     - secure: "CThhdBCfpxP8l3hxrsyZTRQ4KF1fFIonK0L7JYSYoUxM0jWhXBi/r+BgMrGPvNZcVY0FKk2my4dzg4wKTVB8Ghosq7FfcQsuUunBMB7R+oWJ3crtRx8GU2auuhQWrKMoWcotrMfUJ0rzfrNE5H4TM5dcIOrW1A/SOSuOihGK8TCIUfdID2oPJlNu/tfA78TRFvAeWDvLZa7adRscJV+eqil18lFhTD37hf4H/Dag1UEiF69+H1QebQ865RUxL8TRf8KpTxAgVVR2ftlDRPZwIkz4bw6EbAOnVe8YHbpAagfnSBA39nWspDk+yPfVpW3bCuspMsGkbGS7KrCDr2y3noVkgssNWQwl5+4OJO2anp5meBHdktB1PZMPTlxZyOFL+ApfvtSzj9eqXAifFcnKIMRNH6YNLMH2/TMmTNiWo9TVben7oP/Ue3yHFjzRTraDelo/ALDJpyNr7cCVcL6IICq1d4JhoqQnMbXJuYyHd+I5beOBxXXOTOCzBIQkwcq4dnkjSiPoJht3KrKSxm7lANyQWo7+8393d0AUBZ4eOTXv2F8VYUwu65UyBkC/oF8jAo7ab3+gl1j8x/wUYhFuw1/M2XISTtkGhdkiakuOcuG724X2S95eM8jhXCUOkJEHSJ8ufIFut+Y3Y14owXRgQ3FvO1A4JjEmBFteF0zsPK0="
     - secure: "Hv6Sj29d9gI63bORCGHVeX5KqEryAAXf9INQL1ABs33a46wVzGCHM/9H/mE3FItHN7RZaeOEeUoDSePOt/8NBtZSAZ1PvbqhMgztvSWtweS9ezzClUHxN3BRZPSyNmZdrK0S9fo+NXgcgqcmOM9gQzrAduHIkWOOwdSGWgT6zNlAZovddwJ8RUtKavZ7U4szJyMtzlQ8S2K8PdTX9glH1U+8ZLHr54uDrhl3WqsCoBEV0GV59eOIaIseDorCEscVj1EDYCPdkYdU6/AWiuUlqXeOvC67CLcu/5W8m05YWXrEhKG+17jEWRPM+G+Kiyj6HccvjTTaXqTsx9ZLuWmSt86mgo15DmJlVtzpvkptgHhheDyp5MkifValXN3gvWzk3VqjHIUh81dP2o8iAWrGfJcYg+8hdv/obfNGvfcSKwgdefIp4B6f/VRvIySvHUqKavj2fEAGDMYHqahHyKGF/VegHuQbCT+F+mI+GdAwun7XzuDVAlftnbrl2kPq7Kjs+ahU4ZIU4pk6eY15rh/WPlR2v0M7O4nfv1IoyHh9F/G6foqwqDoT+RBF1VMr9WDEezz5B35si6ILI/+SG/7BnbHkFRGorOw86ZqMoIs7dkdpz8uHiz+ba83COuASbrHUMfTG3HQ65XY7puqccSPBQzg7yoVmqPUJJNkaroVMWmU="
 
 # Some of the instructions to install and run minikube are from https://blog.travis-ci.com/2017-10-26-running-kubernetes-on-travis-ci-with-minikube
 before_install:
-  - go get -u github.com/golang/dep/cmd/dep
   - |
-    V=0.9.0
-    OS=linux
-    wget -nv -O install.sh "https://github.com/bazelbuild/bazel/releases/download/${V}/bazel-${V}-installer-${OS}-x86_64.sh"
+    curl -Lo dep "https://github.com/golang/dep/releases/download/${DEP_VERSION}/dep-linux-amd64"
+    chmod +x dep
+    sudo mv dep /usr/local/bin/
+  - |
+    curl -Lo install.sh "https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VERSION}/bazel-${BAZEL_VERSION}-installer-linux-x86_64.sh"
     chmod +x install.sh
     ./install.sh --user
     rm -f install.sh
     mv .bazelrc.travis .bazelrc
   - |
-    curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/v1.9.1/bin/linux/amd64/kubectl
+    curl -Lo kubectl "https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl"
     chmod +x kubectl
     sudo mv kubectl /usr/local/bin/
   - |

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ setup-dev: setup-base
 
 .PHONY: setup-base
 setup-base:
-	dep ensure
+	dep ensure -vendor-only
 	# workaround https://github.com/kubernetes/kubernetes/issues/50975
 	cp fixed_BUILD_for_sets.bazel vendor/k8s.io/apimachinery/pkg/util/sets/BUILD
 	go build -i -o build/bin/buildozer vendor/github.com/bazelbuild/buildtools/buildozer/*.go


### PR DESCRIPTION
- Go 1.9.3
- `dep ensure` only pulls vendor, does not analyze imports
- `dep` is installed as a binary, not via `go get`