### PR TITLE
Remove support for running without aggregation layer

### DIFF
--- a/docs/deployment/3-deployment.yaml
+++ b/docs/deployment/3-deployment.yaml
@@ -14,7 +14,5 @@ spec:
       - name: smith
         image: "atlassianlabs/smith:0.0.X-XXXX"
 #        args:
-#        - '-service-catalog-url'
-#        - 'http://catalog-catalog-apiserver.catalog'
 #        - '-namespace'
 #        - "<your namespace>"

--- a/examples/service_catalog/cleanup.sh
+++ b/examples/service_catalog/cleanup.sh
@@ -7,6 +7,6 @@ kubectl delete service/service1
 kubectl delete ingress/ingress1
 kubectl delete secrets/secret1
 kubectl delete secrets/secret2
-kubectl delete serviceinstance/instance1 --context=service-catalog
-kubectl delete servicebinding/binding1 --context=service-catalog
-kubectl delete servicebinding/binding2 --context=service-catalog
+kubectl delete serviceinstance/instance1
+kubectl delete servicebinding/binding1
+kubectl delete servicebinding/binding2

--- a/it/BUILD.bazel
+++ b/it/BUILD.bazel
@@ -19,7 +19,6 @@ go_library(
         "//pkg/util:go_default_library",
         "//pkg/util/testing:go_default_library",
         "//vendor/github.com/ash2k/stager:go_default_library",
-        "//vendor/github.com/kubernetes-incubator/service-catalog/pkg/client/clientset_generated/clientset:go_default_library",
         "//vendor/github.com/pkg/errors:go_default_library",
         "//vendor/github.com/stretchr/testify/assert:go_default_library",
         "//vendor/github.com/stretchr/testify/require:go_default_library",

--- a/it/utils_for_tests.go
+++ b/it/utils_for_tests.go
@@ -22,7 +22,6 @@ import (
 	smith_testing "github.com/atlassian/smith/pkg/util/testing"
 
 	"github.com/ash2k/stager"
-	scClientset "github.com/kubernetes-incubator/service-catalog/pkg/client/clientset_generated/clientset"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -143,16 +142,8 @@ func SetupApp(t *testing.T, bundle *smith_v1.Bundle, serviceCatalog, createBundl
 		}
 	}
 	config, clientset, bundleClient := TestSetup(t)
-	var scConfig *rest.Config
-	var scClient scClientset.Interface
-	if serviceCatalog {
-		scConfig = config
-		var err error
-		scClient, err = scClientset.NewForConfig(scConfig)
-		require.NoError(t, err)
-	}
 
-	sc := smart.NewClient(config, scConfig, clientset, scClient)
+	sc := smart.NewClient(config, clientset)
 
 	scheme, err := apitypes.FullScheme(serviceCatalog)
 	require.NoError(t, err)
@@ -206,10 +197,10 @@ func SetupApp(t *testing.T, bundle *smith_v1.Bundle, serviceCatalog, createBundl
 
 	stage.StartWithContext(func(ctx context.Context) {
 		apl := app.App{
-			RestConfig:           config,
-			ServiceCatalogConfig: scConfig,
-			Namespace:            cfg.Namespace,
-			Workers:              2,
+			RestConfig:            config,
+			ServiceCatalogSupport: serviceCatalog,
+			Namespace:             cfg.Namespace,
+			Workers:               2,
 		}
 		if e := apl.Run(ctx); e != context.Canceled && e != context.DeadlineExceeded {
 			assert.NoError(t, e)

--- a/pkg/client/smart/BUILD.bazel
+++ b/pkg/client/smart/BUILD.bazel
@@ -9,8 +9,6 @@ go_library(
     importpath = "github.com/atlassian/smith/pkg/client/smart",
     visibility = ["//visibility:public"],
     deps = [
-        "//vendor/github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog/v1beta1:go_default_library",
-        "//vendor/github.com/kubernetes-incubator/service-catalog/pkg/client/clientset_generated/clientset:go_default_library",
         "//vendor/github.com/pkg/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/meta:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
@@ -24,10 +22,7 @@ go_library(
 
 go_test(
     name = "go_default_test",
-    size = "small",
     srcs = ["discovery_test.go"],
     embed = [":go_default_library"],
-    importpath = "github.com/atlassian/smith/pkg/client/smart",
-    race = "on",
     deps = ["//vendor/k8s.io/client-go/discovery:go_default_library"],
 )

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -693,12 +693,8 @@ func (tc *testCase) run(t *testing.T) {
 	restMapper := restMapperFromScheme(scheme)
 
 	sc := &smart.DynamicClient{
-		CoreDynamic: dynamic.NewClientPool(clientConfig, restMapper, dynamic.LegacyAPIPathResolverFunc),
-		Mapper:      restMapper,
-	}
-	if tc.enableServiceCatalog {
-		sc.ScDynamic = sc.CoreDynamic
-		sc.ScMapper = restMapper
+		ClientPool: dynamic.NewClientPool(clientConfig, restMapper, dynamic.LegacyAPIPathResolverFunc),
+		Mapper:     restMapper,
 	}
 
 	stgr := stager.New()


### PR DESCRIPTION
Service Catalog, when installed via helm chart, sits behind the aggregation layer. So now there is no need for this hack anymore.