### PR TITLE
Scheme does not recognize CR types

### DIFF
--- a/it/update_test.go
+++ b/it/update_test.go
@@ -213,6 +213,7 @@ func testUpdate(ctxTest context.Context, t *testing.T, cfg *Config, args ...inte
 	sleeper1 := args[3].(*sleeper_v1.Sleeper)
 	sleeper2 := args[4].(*sleeper_v1.Sleeper)
 	bundle2 := args[5].(*smith_v1.Bundle)
+	convertBundleResourcesToUnstrucutred(t, bundle2, false)
 
 	cmClient := cfg.Clientset.CoreV1().ConfigMaps(cfg.Namespace)
 	secretClient := cfg.Clientset.CoreV1().Secrets(cfg.Namespace)

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -1160,7 +1160,7 @@ func (f *fakeActionHandler) ServeHTTP(response http.ResponseWriter, request *htt
 		fakeResp = fakeResponse{
 			statusCode: http.StatusInternalServerError,
 		}
-	} else {
+	} else if len(fakeResp.content) != 0 {
 		response.Header().Set("Content-Type", "application/json")
 	}
 	response.WriteHeader(fakeResp.statusCode)

--- a/pkg/speccheck/speccheck.go
+++ b/pkg/speccheck/speccheck.go
@@ -50,6 +50,7 @@ func (sc *SpecCheck) applyDefaults(spec runtime.Object) (runtime.Object, error) 
 		return nil, errors.Wrap(err, "failed to convert to typed object")
 	}
 	sc.Scheme.Default(clone)
+	clone.GetObjectKind().SetGroupVersionKind(gvk)
 	return clone, nil
 }
 


### PR DESCRIPTION
Cannot use Scheme to convert to/from unregistered types. Fixes a regression introduced in #228.