### PR TITLE
Add Meta field to Bundle output from //cmd/crd

### DIFF
--- a/pkg/resources/crd_helpers.go
+++ b/pkg/resources/crd_helpers.go
@@ -178,6 +178,10 @@ func BundleCrd() *apiext_v1b1.CustomResourceDefinition {
 	}
 
 	return &apiext_v1b1.CustomResourceDefinition{
+		TypeMeta: meta_v1.TypeMeta{
+			Kind: "CustomResourceDefinition",
+			APIVersion: apiext_v1b1.SchemeGroupVersion.String(),
+		},
 		ObjectMeta: meta_v1.ObjectMeta{
 			Name: smith_v1.BundleResourceName,
 		},


### PR DESCRIPTION
The output for 
```
bazel run //cmd/crd -- -print-bundle=yaml
```
Was missing the following:
```
apiVersion: apiextensions.k8s.io/v1beta1
kind: CustomResourceDefinition
```

Which made it impossible to pipe into `kubectl create`

This PR adds those fields which get omitted when empty.