### PR TITLE
Send logs from zap to t.Log()

### DIFF
--- a/examples/sleeper/main/main.go
+++ b/examples/sleeper/main/main.go
@@ -50,7 +50,7 @@ func runWithContext(ctx context.Context) error {
 
 func runWithConfig(ctx context.Context, config *rest.Config) error {
 	a := sleeper.App{
-		Logger:     logz.DevelopmentLogger(),
+		Logger:     logz.Logger("debug", "console"),
 		RestConfig: config,
 	}
 	return a.Run(ctx)

--- a/it/utils_for_tests.go
+++ b/it/utils_for_tests.go
@@ -17,7 +17,6 @@ import (
 	"github.com/atlassian/smith/pkg/client/smart"
 	"github.com/atlassian/smith/pkg/resources"
 	"github.com/atlassian/smith/pkg/util"
-	"github.com/atlassian/smith/pkg/util/logz"
 	smith_testing "github.com/atlassian/smith/pkg/util/testing"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
@@ -178,7 +177,7 @@ func SetupApp(t *testing.T, bundle *smith_v1.Bundle, serviceCatalog, createBundl
 
 	sc := smart.NewClient(config, clientset)
 
-	logger := logz.DevelopmentLogger()
+	logger := smith_testing.DevelopmentLogger(t)
 	defer logger.Sync()
 
 	cfg := &Config{

--- a/pkg/controller_test/zz_plumbing_for_test.go
+++ b/pkg/controller_test/zz_plumbing_for_test.go
@@ -27,7 +27,7 @@ import (
 	"github.com/atlassian/smith/pkg/speccheck"
 	"github.com/atlassian/smith/pkg/store"
 	"github.com/atlassian/smith/pkg/util"
-	"github.com/atlassian/smith/pkg/util/logz"
+	smith_testing "github.com/atlassian/smith/pkg/util/testing"
 	sc_v1b1 "github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog/v1beta1"
 	scClientset "github.com/kubernetes-incubator/service-catalog/pkg/client/clientset_generated/clientset"
 	scFake "github.com/kubernetes-incubator/service-catalog/pkg/client/clientset_generated/clientset/fake"
@@ -243,7 +243,7 @@ func (tc *testCase) run(t *testing.T) {
 	crdStore, err := store.NewCrd(crdInf)
 	require.NoError(t, err)
 
-	tc.logger = logz.DevelopmentLogger()
+	tc.logger = smith_testing.DevelopmentLogger(t)
 	defer tc.logger.Sync()
 
 	// Ready Checker

--- a/pkg/speccheck/speccheck_test.go
+++ b/pkg/speccheck/speccheck_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/atlassian/smith/pkg/cleanup"
-	"github.com/atlassian/smith/pkg/util/logz"
+	smith_testing "github.com/atlassian/smith/pkg/util/testing"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/api/equality"
@@ -20,7 +20,7 @@ func TestUpdateResourceEmptyMissingNilNoChanges(t *testing.T) {
 		"missing": missingMap,
 		"nil":     nilMap,
 	}
-	logger := logz.DevelopmentLogger()
+	logger := smith_testing.DevelopmentLogger(t)
 	defer logger.Sync()
 
 	for kind1, input1 := range inputs {

--- a/pkg/util/logz/logz.go
+++ b/pkg/util/logz/logz.go
@@ -73,18 +73,3 @@ func Logger(loggingLevel, logEncoding string) *zap.Logger {
 		),
 	)
 }
-
-func DevelopmentLogger() *zap.Logger {
-	cfg := zap.NewProductionEncoderConfig()
-	cfg.EncodeTime = zapcore.ISO8601TimeEncoder
-	lockedSyncer := zapcore.Lock(zapcore.AddSync(os.Stderr))
-	return zap.New(
-		zapcore.NewCore(
-			zapcore.NewConsoleEncoder(cfg),
-			lockedSyncer,
-			zap.InfoLevel,
-		),
-		zap.Development(),
-		zap.ErrorOutput(lockedSyncer),
-	)
-}


### PR DESCRIPTION
Hey, guys, check this out. Quite nice to see logs only for the failing test even if tests are run concurrently. Should use this everywhere.
Example output from another project:
```console
--- FAIL: TestCredsForUnknownRole (0.01s)
    --- FAIL: TestCredsForUnknownRole/role_added_and_removed_after_creds_fetched (0.00s)
        utils_for_tests.go:35: 2018-03-19T10:54:41.530Z debug   Starting worker
        utils_for_tests.go:35: 2018-03-19T10:54:41.530Z debug   Starting worker
        utils_for_tests.go:35: 2018-03-19T10:54:41.530Z debug   Attempting to fetch credentials for IAM role    {"role_arn": "arn:aws:iam::123456789012:role/this/is/a/path/roleName", "session_name": "default/serviceaccounts/accountname"}
        utils_for_tests.go:35: 2018-03-19T10:54:41.530Z debug   Successfully fetched credentials for IAM role   {"role_arn": "arn:aws:iam::123456789012:role/this/is/a/path/roleName", "session_name": "default/serviceaccounts/accountname"}
        assertions.go:238: 
                        Error Trace:    prefetcher_test.go:229
                        Error:          Not equal: 
                                        expected: context.deadlineExceededError(context.deadlineExceededError{})
                                        actual  : <nil>(<nil>)
                        Test:           TestCredsForUnknownRole/role_added_and_removed_after_creds_fetched
        utils_for_tests.go:35: 2018-03-19T10:54:41.531Z debug   Stopping worker
        utils_for_tests.go:35: 2018-03-19T10:54:41.531Z debug   Stopping worker
FAIL
```