### PR TITLE
Use json-based diff instead of reflect-based one in speccheck.CompareActualVsSpec

### DIFF
--- a/pkg/speccheck/speccheck.go
+++ b/pkg/speccheck/speccheck.go
@@ -96,8 +96,7 @@ func (sc *SpecCheck) compareActualVsSpec(spec, actual *unstructured.Unstructured
 			return updated, false, nil
 		}
 
-		sc.Logger.Sugar().Infof("Objects are different: %s",
-			diff.ObjectReflectDiff(updated.Object, actualClone.Object))
+		sc.Logger.Sugar().Infof("Objects are different: %s", diff.ObjectDiff(updated.Object, actualClone.Object))
 		return updated, false, nil
 	}
 	return actual, true, nil

--- a/pkg/speccheck/speccheck_test.go
+++ b/pkg/speccheck/speccheck_test.go
@@ -1,10 +1,9 @@
 package speccheck
 
 import (
+	"encoding/json"
 	"fmt"
 	"testing"
-
-	"encoding/json"
 
 	"github.com/atlassian/smith/pkg/cleanup"
 	"github.com/atlassian/smith/pkg/cleanup/types"


### PR DESCRIPTION
The problem is that diff.ObjectReflectDiff doesn't work well (e.g. panics) when compared objects have completely different schemas (say field x is type of map in A and type of string in B). I can't easily fix this in Kube codebase because this method assumes schema-equality in multiple places. To be fair they check if the types match, they just don't expect the same type can have instances of different shape, like Service Catalog's ServiceInstance can have due to spec.parameters being arbitrary structures (e.g. environment is a string for resource X and map for resource Y).