### PR TITLE
Make topological sort deterministic

### DIFF
--- a/pkg/util/graph/topological_sort.go
+++ b/pkg/util/graph/topological_sort.go
@@ -27,7 +27,7 @@ func (g *Graph) visit(name V, results *orderedset, visited *orderedset) error {
 	}
 
 	n := g.Vertices[name]
-	for _, edge := range n.Edges() {
+	for _, edge := range n.OutgoingEdges {
 		err := g.visit(edge, results, visited.clone())
 		if err != nil {
 			return err

--- a/pkg/util/graph/topological_sort_test.go
+++ b/pkg/util/graph/topological_sort_test.go
@@ -1,6 +1,7 @@
 package graph
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -93,6 +94,27 @@ func TestSortMissingVertexError(t *testing.T) {
 	g := initGraph()
 
 	require.Error(t, g.AddEdge("a", "x"), "vertex \"x\" not found")
+}
+
+func TestSortIsDeterministic(t *testing.T) {
+	t.Parallel()
+
+	for n := 0; n <= 100; n++ {
+		t.Run(fmt.Sprintf("Case%v", n), sortIsDeterministic)
+	}
+}
+
+func sortIsDeterministic(t *testing.T) {
+	g := initGraph()
+
+	// a -> b
+	// a -> c
+	// a -> d
+	require.NoError(t, g.AddEdge("a", "b"))
+	require.NoError(t, g.AddEdge("a", "c"))
+	require.NoError(t, g.AddEdge("a", "d"))
+
+	assertSortResult(t, g, []V{"b", "c", "d", "a"})
 }
 
 func initGraph() *Graph {

--- a/pkg/util/graph/types.go
+++ b/pkg/util/graph/types.go
@@ -10,14 +10,15 @@ type D interface{}
 
 // Vertex is a resource representation in a dependency graph.
 type Vertex struct {
-	EdgesSet map[V]struct{}
-	Data     D
+	// Edges in order of appearance (for deterministic order after sort).
+	OutgoingEdges []V
+	Data          D
 }
 
 // Graph is a graph representation of resource dependencies.
 type Graph struct {
 	// Vertices is a map from resource name to resource vertex.
-	Vertices map[V]Vertex
+	Vertices map[V]*Vertex
 
 	// Vertices in order of appearance (for deterministic order after sort).
 	orderedVertices []V
@@ -25,16 +26,15 @@ type Graph struct {
 
 func NewGraph(size int) *Graph {
 	return &Graph{
-		Vertices:        make(map[V]Vertex, size),
+		Vertices:        make(map[V]*Vertex, size),
 		orderedVertices: make([]V, 0, size),
 	}
 }
 
 func (g *Graph) AddVertex(name V, data D) {
 	if !g.ContainsVertex(name) {
-		g.Vertices[name] = Vertex{
-			EdgesSet: make(map[V]struct{}),
-			Data:     data,
+		g.Vertices[name] = &Vertex{
+			Data: data,
 		}
 		g.orderedVertices = append(g.orderedVertices, name)
 	}
@@ -59,15 +59,6 @@ func (g *Graph) ContainsVertex(name V) bool {
 	return ok
 }
 
-func (v Vertex) addEdge(name V) {
-	v.EdgesSet[name] = struct{}{}
-}
-
-// Edges returns a list of resources current resource depends on.
-func (v Vertex) Edges() []V {
-	keys := make([]V, 0, len(v.EdgesSet))
-	for k := range v.EdgesSet {
-		keys = append(keys, k)
-	}
-	return keys
+func (v *Vertex) addEdge(name V) {
+	v.OutgoingEdges = append(v.OutgoingEdges, name)
 }


### PR DESCRIPTION
Because current implementation iterates over map of edges and iterating over maps is not deterministic the final sort result is not deterministic too.

This causes Bundles to be constantly updated by orchestration controller.