### PR TITLE
gometalinter: golint

### DIFF
--- a/.gometalinter.json
+++ b/.gometalinter.json
@@ -1,7 +1,8 @@
 {
   "Cyclo": 30,
-  "Deadline": "800s",
+  "Deadline": "20m",
   "Exclude": [
+    "comment",
     "zz_generated"
   ],
   "Skip": [

--- a/Makefile
+++ b/Makefile
@@ -8,8 +8,8 @@ setup-dev: setup-ci
 
 .PHONY: setup-ci
 setup-ci: setup-base
-	go get -u github.com/alecthomas/gometalinter
-	gometalinter --install --force
+	go get -u gopkg.in/alecthomas/gometalinter.v2
+	gometalinter.v2 --install --force
 
 .PHONY: setup-base
 setup-base:
@@ -147,13 +147,13 @@ quick-test:
 
 .PHONY: check
 check:
-	gometalinter --concurrency=$(METALINTER_CONCURRENCY) ./... \
+	gometalinter.v2 --concurrency=$(METALINTER_CONCURRENCY) ./... \
 		--linter='errcheck:errcheck:-ignore=net:Close' \
 		--disable=interfacer --disable=golint
 
 .PHONY: check-all
 check-all:
-	gometalinter --concurrency=$(METALINTER_CONCURRENCY) ./...
+	gometalinter.v2 --concurrency=$(METALINTER_CONCURRENCY) ./...
 
 .PHONY: docker
 docker:

--- a/Makefile
+++ b/Makefile
@@ -149,7 +149,7 @@ quick-test:
 check:
 	gometalinter.v2 --concurrency=$(METALINTER_CONCURRENCY) ./... \
 		--linter='errcheck:errcheck:-ignore=net:Close' \
-		--disable=interfacer --disable=golint
+		--disable=interfacer
 
 .PHONY: check-all
 check-all:

--- a/cmd/smith/app/bundle_controller.go
+++ b/cmd/smith/app/bundle_controller.go
@@ -45,8 +45,8 @@ type BundleControllerConstructor struct {
 
 	// To override things constructed by default. And for tests.
 	SmithClient  smithClientset.Interface
-	ScClient     scClientset.Interface
-	ApiExtClient apiExtClientset.Interface
+	SCClient     scClientset.Interface
+	APIExtClient apiExtClientset.Interface
 	SmartClient  bundlec.SmartClient
 }
 
@@ -76,14 +76,14 @@ func (c *BundleControllerConstructor) New(config *ctrl.Config, cctx *ctrl.Contex
 			return nil, err
 		}
 	}
-	scClient := c.ScClient
+	scClient := c.SCClient
 	if scClient == nil {
 		scClient, err = scClientset.NewForConfig(config.RestConfig)
 		if err != nil {
 			return nil, err
 		}
 	}
-	apiExtClient := c.ApiExtClient
+	apiExtClient := c.APIExtClient
 	if apiExtClient == nil {
 		apiExtClient, err = apiExtClientset.NewForConfig(config.RestConfig)
 		if err != nil {
@@ -199,10 +199,10 @@ func (c *BundleControllerConstructor) Describe() ctrl.Descriptor {
 	}
 }
 
-func (c *BundleControllerConstructor) loadPlugins() (map[smith_v1.PluginName]plugin.PluginContainer, error) {
-	pluginContainers := make(map[smith_v1.PluginName]plugin.PluginContainer, len(c.Plugins))
+func (c *BundleControllerConstructor) loadPlugins() (map[smith_v1.PluginName]plugin.Container, error) {
+	pluginContainers := make(map[smith_v1.PluginName]plugin.Container, len(c.Plugins))
 	for _, p := range c.Plugins {
-		pluginContainer, err := plugin.NewPluginContainer(p)
+		pluginContainer, err := plugin.NewContainer(p)
 		if err != nil {
 			return nil, err
 		}

--- a/cmd/smith/main.go
+++ b/cmd/smith/main.go
@@ -13,7 +13,7 @@ import (
 
 func main() {
 	if err := run(); err != nil && err != context.Canceled && err != context.DeadlineExceeded {
-		fmt.Fprintf(os.Stderr, "%#v\n", err)
+		fmt.Fprintf(os.Stderr, "%#v\n", err) // nolint: gas
 		os.Exit(1)
 	}
 }

--- a/examples/sleeper/app.go
+++ b/examples/sleeper/app.go
@@ -40,13 +40,13 @@ func (a *App) sleeperInformer(ctx context.Context, sClient rest.Interface) cache
 		cache.NewListWatchFromClient(sClient, sleeper_v1.SleeperResourcePlural, a.Namespace, fields.Everything()),
 		&sleeper_v1.Sleeper{}, ResyncPeriod)
 
-	seh := &SleeperEventHandler{
+	eh := &EventHandler{
 		ctx:    ctx,
 		logger: a.Logger,
 		client: sClient,
 	}
 
-	sleeperInf.AddEventHandler(seh)
+	sleeperInf.AddEventHandler(eh)
 
 	return sleeperInf
 }

--- a/examples/sleeper/client.go
+++ b/examples/sleeper/client.go
@@ -35,7 +35,7 @@ func Client(cfg *rest.Config) (*rest.RESTClient, error) {
 	return rest.RESTClientFor(&config)
 }
 
-func SleeperCrd() *apiext_v1b1.CustomResourceDefinition {
+func Crd() *apiext_v1b1.CustomResourceDefinition {
 	return &apiext_v1b1.CustomResourceDefinition{
 		ObjectMeta: meta_v1.ObjectMeta{
 			Name: sleeper_v1.SleeperResourceName,

--- a/examples/sleeper/main/main.go
+++ b/examples/sleeper/main/main.go
@@ -15,7 +15,7 @@ import (
 
 func main() {
 	if err := run(); err != nil && err != context.Canceled && err != context.DeadlineExceeded {
-		fmt.Fprintf(os.Stderr, "%#v", err)
+		fmt.Fprintf(os.Stderr, "%#v", err) // nolint: gas
 		os.Exit(1)
 	}
 }

--- a/examples/sleeper/pkg/apis/sleeper/v1/types_test.go
+++ b/examples/sleeper/pkg/apis/sleeper/v1/types_test.go
@@ -30,7 +30,7 @@ func TestGetJsonPathStringSleeper(t *testing.T) {
 	unstructured := make(map[string]interface{})
 	err = json.Unmarshal(bytes, &unstructured)
 	require.NoError(t, err)
-	status, err := resources.GetJsonPathString(unstructured, SleeperReadyStatePath)
+	status, err := resources.GetJSONPathString(unstructured, SleeperReadyStatePath)
 	require.NoError(t, err)
 	assert.Equal(t, string(SleeperReadyStateValue), status)
 }

--- a/examples/sleeper/sleeper_event_handler.go
+++ b/examples/sleeper/sleeper_event_handler.go
@@ -11,27 +11,27 @@ import (
 	"k8s.io/client-go/rest"
 )
 
-type SleeperEventHandler struct {
+type EventHandler struct {
 	ctx    context.Context
 	logger *zap.Logger
 	client rest.Interface
 }
 
-func (h *SleeperEventHandler) OnAdd(obj interface{}) {
+func (h *EventHandler) OnAdd(obj interface{}) {
 	h.handle(obj)
 }
 
-func (h *SleeperEventHandler) OnUpdate(oldObj, newObj interface{}) {
+func (h *EventHandler) OnUpdate(oldObj, newObj interface{}) {
 	in := *newObj.(*sleeper_v1.Sleeper)
 	if in.Status.State == sleeper_v1.New {
 		h.handle(newObj)
 	}
 }
 
-func (h *SleeperEventHandler) OnDelete(obj interface{}) {
+func (h *EventHandler) OnDelete(obj interface{}) {
 }
 
-func (h *SleeperEventHandler) handle(obj interface{}) {
+func (h *EventHandler) handle(obj interface{}) {
 	in := obj.(*sleeper_v1.Sleeper).DeepCopy()
 	msg := in.Spec.WakeupMessage
 	logger := h.logger.With(ctrlLogz.Namespace(in), ctrlLogz.Object(in))
@@ -55,7 +55,7 @@ func (h *SleeperEventHandler) handle(obj interface{}) {
 	}()
 }
 
-func (h *SleeperEventHandler) retryUpdate(sleeper *sleeper_v1.Sleeper, state sleeper_v1.SleeperState, message string) error {
+func (h *EventHandler) retryUpdate(sleeper *sleeper_v1.Sleeper, state sleeper_v1.SleeperState, message string) error {
 	for {
 		sleeper.Status.State = state
 		sleeper.Status.Message = message

--- a/it/utils_for_tests.go
+++ b/it/utils_for_tests.go
@@ -239,7 +239,7 @@ func SetupApp(t *testing.T, bundle *smith_v1.Bundle, serviceCatalog, createBundl
 	}
 
 	crdLister := apiext_v1b1list.NewCustomResourceDefinitionLister(crdInf.GetIndexer())
-	require.NoError(t, resources.EnsureCrdExistsAndIsEstablished(ctxTest, logger, apiExtClient, crdLister, sleeper.SleeperCrd()))
+	require.NoError(t, resources.EnsureCrdExistsAndIsEstablished(ctxTest, logger, apiExtClient, crdLister, sleeper.Crd()))
 	require.NoError(t, resources.EnsureCrdExistsAndIsEstablished(ctxTest, logger, apiExtClient, crdLister, resources.BundleCrd()))
 
 	stage.StartWithContext(func(ctx context.Context) {

--- a/pkg/cleanup/types/built_in.go
+++ b/pkg/cleanup/types/built_in.go
@@ -24,21 +24,21 @@ var (
 		{Group: sc_v1b1.GroupName, Kind: "ServiceInstance"}: scServiceInstanceCleanup,
 	}
 
-	apps_v1_scheme = runtime.NewScheme()
-	sc_v1b1_scheme = runtime.NewScheme()
-	core_v1_scheme = runtime.NewScheme()
+	appsV1Scheme = runtime.NewScheme()
+	scV1B1Scheme = runtime.NewScheme()
+	coreV1Scheme = runtime.NewScheme()
 )
 
 func init() {
-	err := apps_v1.SchemeBuilder.AddToScheme(apps_v1_scheme)
+	err := apps_v1.SchemeBuilder.AddToScheme(appsV1Scheme)
 	if err != nil {
 		panic(err)
 	}
-	err = sc_v1b1.SchemeBuilder.AddToScheme(sc_v1b1_scheme)
+	err = sc_v1b1.SchemeBuilder.AddToScheme(scV1B1Scheme)
 	if err != nil {
 		panic(err)
 	}
-	err = core_v1.SchemeBuilder.AddToScheme(core_v1_scheme)
+	err = core_v1.SchemeBuilder.AddToScheme(coreV1Scheme)
 	if err != nil {
 		panic(err)
 	}
@@ -46,7 +46,7 @@ func init() {
 
 func deploymentCleanup(spec, actual *unstructured.Unstructured) (runtime.Object, error) {
 	var deploymentSpec apps_v1.Deployment
-	if err := util.ConvertType(apps_v1_scheme, spec, &deploymentSpec); err != nil {
+	if err := util.ConvertType(appsV1Scheme, spec, &deploymentSpec); err != nil {
 		return nil, err
 	}
 
@@ -57,11 +57,11 @@ func deploymentCleanup(spec, actual *unstructured.Unstructured) (runtime.Object,
 
 func serviceCleanup(spec, actual *unstructured.Unstructured) (runtime.Object, error) {
 	var serviceSpec core_v1.Service
-	if err := util.ConvertType(core_v1_scheme, spec, &serviceSpec); err != nil {
+	if err := util.ConvertType(coreV1Scheme, spec, &serviceSpec); err != nil {
 		return nil, err
 	}
 	var serviceActual core_v1.Service
-	if err := util.ConvertType(core_v1_scheme, actual, &serviceActual); err != nil {
+	if err := util.ConvertType(coreV1Scheme, actual, &serviceActual); err != nil {
 		return nil, err
 	}
 
@@ -86,7 +86,7 @@ func serviceCleanup(spec, actual *unstructured.Unstructured) (runtime.Object, er
 
 func secretCleanup(spec, actual *unstructured.Unstructured) (runtime.Object, error) {
 	var secretSpec core_v1.Secret
-	if err := util.ConvertType(core_v1_scheme, spec, &secretSpec); err != nil {
+	if err := util.ConvertType(coreV1Scheme, spec, &secretSpec); err != nil {
 		return nil, err
 	}
 
@@ -106,11 +106,11 @@ func secretCleanup(spec, actual *unstructured.Unstructured) (runtime.Object, err
 
 func scServiceBindingCleanup(spec, actual *unstructured.Unstructured) (runtime.Object, error) {
 	var sbSpec sc_v1b1.ServiceBinding
-	if err := util.ConvertType(sc_v1b1_scheme, spec, &sbSpec); err != nil {
+	if err := util.ConvertType(scV1B1Scheme, spec, &sbSpec); err != nil {
 		return nil, err
 	}
 	var sbActual sc_v1b1.ServiceBinding
-	if err := util.ConvertType(sc_v1b1_scheme, actual, &sbActual); err != nil {
+	if err := util.ConvertType(scV1B1Scheme, actual, &sbActual); err != nil {
 		return nil, err
 	}
 
@@ -125,11 +125,11 @@ func scServiceBindingCleanup(spec, actual *unstructured.Unstructured) (runtime.O
 
 func scServiceInstanceCleanup(spec, actual *unstructured.Unstructured) (runtime.Object, error) {
 	var instanceSpec sc_v1b1.ServiceInstance
-	if err := util.ConvertType(sc_v1b1_scheme, spec, &instanceSpec); err != nil {
+	if err := util.ConvertType(scV1B1Scheme, spec, &instanceSpec); err != nil {
 		return nil, err
 	}
 	var instanceActual sc_v1b1.ServiceInstance
-	if err := util.ConvertType(sc_v1b1_scheme, actual, &instanceActual); err != nil {
+	if err := util.ConvertType(scV1B1Scheme, actual, &instanceActual); err != nil {
 		return nil, err
 	}
 

--- a/pkg/client/bundle.go
+++ b/pkg/client/bundle.go
@@ -12,14 +12,14 @@ import (
 )
 
 func BundleInformer(smithClient smithClientset.Interface, namespace string, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	bundlesApi := smithClient.SmithV1().Bundles(namespace)
+	bundlesAPI := smithClient.SmithV1().Bundles(namespace)
 	return cache.NewSharedIndexInformer(
 		&cache.ListWatch{
 			ListFunc: func(options meta_v1.ListOptions) (runtime.Object, error) {
-				return bundlesApi.List(options)
+				return bundlesAPI.List(options)
 			},
 			WatchFunc: func(options meta_v1.ListOptions) (watch.Interface, error) {
-				return bundlesApi.Watch(options)
+				return bundlesAPI.Watch(options)
 			},
 		},
 		&smith_v1.Bundle{},

--- a/pkg/client/config.go
+++ b/pkg/client/config.go
@@ -39,12 +39,12 @@ func LoadConfig(configFileFrom, configFileName, configContext string) (*rest.Con
 	case "environment":
 		config, err = ConfigFromEnv()
 	case "file":
-		var configApi *clientcmdapi.Config
-		configApi, err = clientcmd.LoadFromFile(configFileName)
+		var configAPI *clientcmdapi.Config
+		configAPI, err = clientcmd.LoadFromFile(configFileName)
 		if err != nil {
 			return nil, errors.Wrapf(err, "failed to load REST client configuration from file %q", configFileName)
 		}
-		config, err = clientcmd.NewDefaultClientConfig(*configApi, &clientcmd.ConfigOverrides{
+		config, err = clientcmd.NewDefaultClientConfig(*configAPI, &clientcmd.ConfigOverrides{
 			CurrentContext: configContext,
 		}).ClientConfig()
 	default:

--- a/pkg/controller/bundlec/bundle_sync_task.go
+++ b/pkg/controller/bundlec/bundle_sync_task.go
@@ -33,7 +33,7 @@ type bundleSyncTask struct {
 	store            Store
 	specCheck        SpecCheck
 	bundle           *smith_v1.Bundle
-	pluginContainers map[smith_v1.PluginName]plugin.PluginContainer
+	pluginContainers map[smith_v1.PluginName]plugin.Container
 	scheme           *runtime.Scheme
 	catalog          *store.Catalog
 

--- a/pkg/controller/bundlec/controller.go
+++ b/pkg/controller/bundlec/controller.go
@@ -45,7 +45,7 @@ type Controller struct {
 	resourceHandler cache.ResourceEventHandler
 	Namespace       string
 
-	PluginContainers map[smith_v1.PluginName]plugin.PluginContainer
+	PluginContainers map[smith_v1.PluginName]plugin.Container
 	Scheme           *runtime.Scheme
 
 	Catalog *store.Catalog

--- a/pkg/controller/bundlec/resource_sync_task.go
+++ b/pkg/controller/bundlec/resource_sync_task.go
@@ -71,7 +71,7 @@ type resourceSyncTask struct {
 	specCheck          SpecCheck
 	bundle             *smith_v1.Bundle
 	processedResources map[smith_v1.ResourceName]*resourceInfo
-	pluginContainers   map[smith_v1.PluginName]plugin.PluginContainer
+	pluginContainers   map[smith_v1.PluginName]plugin.Container
 	scheme             *runtime.Scheme
 	catalog            *store.Catalog
 }

--- a/pkg/controller/bundlec/spec_processor.go
+++ b/pkg/controller/bundlec/spec_processor.go
@@ -186,7 +186,7 @@ func resolveReference(resInfos map[smith_v1.ResourceName]*resourceInfo, referenc
 	// To avoid overcomplicated format of reference like this: {{res1#{$.a.string}}}
 	// And have something like this instead: {{res1#a.string}}
 	jsonPath := fmt.Sprintf("{$.%s}", reference.Path)
-	fieldValue, err := resources.GetJsonPathValue(objToTraverse, jsonPath, false)
+	fieldValue, err := resources.GetJSONPathValue(objToTraverse, jsonPath, false)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to process reference %q", reference.Name)
 	}

--- a/pkg/controller/bundlec_test/zz_plumbing_for_test.go
+++ b/pkg/controller/bundlec_test/zz_plumbing_for_test.go
@@ -260,8 +260,8 @@ func (tc *testCase) run(t *testing.T) {
 		Plugins:               plugins,
 		ServiceCatalogSupport: tc.enableServiceCatalog,
 		SmithClient:           smithClient,
-		ScClient:              scClient,
-		ApiExtClient:          apiExtClient,
+		SCClient:              scClient,
+		APIExtClient:          apiExtClient,
 		SmartClient: &smart.DynamicClient{
 			ClientPool: dynamic.NewClientPool(clientConfig, restMapper, dynamic.LegacyAPIPathResolverFunc),
 			Mapper:     restMapper,
@@ -467,7 +467,7 @@ func (f *fakeActionHandler) ServeHTTP(response http.ResponseWriter, request *htt
 }
 
 func SleeperCrdWithStatus() *apiext_v1b1.CustomResourceDefinition {
-	crd := sleeper.SleeperCrd()
+	crd := sleeper.Crd()
 	crd.Status = apiext_v1b1.CustomResourceDefinitionStatus{
 		Conditions: []apiext_v1b1.CustomResourceDefinitionCondition{
 			{Type: apiext_v1b1.Established, Status: apiext_v1b1.ConditionTrue},

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -7,32 +7,32 @@ import (
 	"github.com/xeipuuv/gojsonschema"
 )
 
-type PluginContainer struct {
+type Container struct {
 	Plugin Plugin
 	schema *gojsonschema.Schema
 }
 
-func NewPluginContainer(newPlugin NewFunc) (PluginContainer, error) {
+func NewContainer(newPlugin NewFunc) (Container, error) {
 	plugin, err := newPlugin()
 	if err != nil {
-		return PluginContainer{}, errors.Wrap(err, "failed to instantiate plugin")
+		return Container{}, errors.Wrap(err, "failed to instantiate plugin")
 	}
 	description := plugin.Describe()
 	var schema *gojsonschema.Schema
 	if description.SpecSchema != nil {
 		schema, err = gojsonschema.NewSchema(gojsonschema.NewBytesLoader(description.SpecSchema))
 		if err != nil {
-			return PluginContainer{}, errors.Wrapf(err, "can't use plugin %q due to invalid schema", description.Name)
+			return Container{}, errors.Wrapf(err, "can't use plugin %q due to invalid schema", description.Name)
 		}
 	}
 
-	return PluginContainer{
+	return Container{
 		Plugin: plugin,
 		schema: schema,
 	}, nil
 }
 
-func (pc *PluginContainer) ValidateSpec(pluginSpec map[string]interface{}) error {
+func (pc *Container) ValidateSpec(pluginSpec map[string]interface{}) error {
 	if pc.schema == nil {
 		return nil
 	}

--- a/pkg/readychecker/ready_checker.go
+++ b/pkg/readychecker/ready_checker.go
@@ -83,7 +83,7 @@ func (rc *ReadyChecker) checkPathValue(gk schema.GroupKind, obj *unstructured.Un
 	if len(path) == 0 || len(value) == 0 {
 		return false, false, nil
 	}
-	actualValue, err := resources.GetJsonPathString(obj.Object, path)
+	actualValue, err := resources.GetJSONPathString(obj.Object, path)
 	if err != nil {
 		return false, false, err
 	}

--- a/pkg/readychecker/types/built_in.go
+++ b/pkg/readychecker/types/built_in.go
@@ -26,16 +26,16 @@ var (
 		{Group: sc_v1b1.GroupName, Kind: "ServiceBinding"}:  isScServiceBindingReady,
 		{Group: sc_v1b1.GroupName, Kind: "ServiceInstance"}: isScServiceInstanceReady,
 	}
-	apps_v1_scheme = runtime.NewScheme()
-	sc_v1b1_scheme = runtime.NewScheme()
+	appsV1Scheme = runtime.NewScheme()
+	scV1B1Scheme = runtime.NewScheme()
 )
 
 func init() {
-	err := apps_v1.SchemeBuilder.AddToScheme(apps_v1_scheme)
+	err := apps_v1.SchemeBuilder.AddToScheme(appsV1Scheme)
 	if err != nil {
 		panic(err)
 	}
-	err = sc_v1b1.SchemeBuilder.AddToScheme(sc_v1b1_scheme)
+	err = sc_v1b1.SchemeBuilder.AddToScheme(scV1B1Scheme)
 	if err != nil {
 		panic(err)
 	}
@@ -49,7 +49,7 @@ func alwaysReady(_ runtime.Object) (isReady, retriableError bool, e error) {
 // and k8s.io/kubernetes/pkg/client/unversioned/conditions.go:120 DeploymentHasDesiredReplicas()
 func isDeploymentReady(obj runtime.Object) (isReady, retriableError bool, e error) {
 	var deployment apps_v1.Deployment
-	if err := util.ConvertType(apps_v1_scheme, obj, &deployment); err != nil {
+	if err := util.ConvertType(appsV1Scheme, obj, &deployment); err != nil {
 		return false, false, err
 	}
 
@@ -64,7 +64,7 @@ func isDeploymentReady(obj runtime.Object) (isReady, retriableError bool, e erro
 
 func isScServiceBindingReady(obj runtime.Object) (isReady, retriableError bool, e error) {
 	var sic sc_v1b1.ServiceBinding
-	if err := util.ConvertType(sc_v1b1_scheme, obj, &sic); err != nil {
+	if err := util.ConvertType(scV1B1Scheme, obj, &sic); err != nil {
 		return false, false, err
 	}
 	readyCond := getServiceBindingCondition(&sic, sc_v1b1.ServiceBindingConditionReady)
@@ -82,7 +82,7 @@ func isScServiceBindingReady(obj runtime.Object) (isReady, retriableError bool, 
 
 func isScServiceInstanceReady(obj runtime.Object) (isReady, retriableError bool, e error) {
 	var instance sc_v1b1.ServiceInstance
-	if err := util.ConvertType(sc_v1b1_scheme, obj, &instance); err != nil {
+	if err := util.ConvertType(scV1B1Scheme, obj, &instance); err != nil {
 		return false, false, err
 	}
 	readyCond := getServiceInstanceCondition(&instance, sc_v1b1.ServiceInstanceConditionReady)

--- a/pkg/resources/crd_helpers.go
+++ b/pkg/resources/crd_helpers.go
@@ -28,7 +28,7 @@ func BundleCrd() *apiext_v1b1.CustomResourceDefinition {
 
 	// definitions are not supported, do what we can :)
 
-	DNS_SUBDOMAIN := apiext_v1b1.JSONSchemaProps{
+	dnsSubdomain := apiext_v1b1.JSONSchemaProps{
 		Type:      "string",
 		MinLength: int64ptr(1),
 		MaxLength: int64ptr(253),
@@ -40,7 +40,7 @@ func BundleCrd() *apiext_v1b1.CustomResourceDefinition {
 		MaxLength: int64ptr(253),
 		Pattern:   `^[a-zA-Z0-9]([-a-zA-Z0-9]*[a-zA-Z0-9])?(\.[a-zA-Z0-9]([-a-zA-Z0-9]*[a-zA-Z0-9])?)*$`,
 	}
-	resourceName := DNS_SUBDOMAIN
+	resourceName := dnsSubdomain
 	apiVersion := apiext_v1b1.JSONSchemaProps{
 		Type:      "string",
 		MinLength: int64ptr(1),
@@ -55,7 +55,7 @@ func BundleCrd() *apiext_v1b1.CustomResourceDefinition {
 		Properties: map[string]apiext_v1b1.JSONSchemaProps{
 			"kind":       kind,
 			"apiVersion": apiVersion,
-			"name":       DNS_SUBDOMAIN,
+			"name":       dnsSubdomain,
 			"blockOwnerDeletion": {
 				Type: "boolean",
 			},
@@ -77,7 +77,7 @@ func BundleCrd() *apiext_v1b1.CustomResourceDefinition {
 		Description: "Schema for some fields of ObjectMeta",
 		Type:        "object",
 		Properties: map[string]apiext_v1b1.JSONSchemaProps{
-			"name": DNS_SUBDOMAIN,
+			"name": dnsSubdomain,
 			"labels": {
 				Type: "object",
 				// TODO there is a bug in marshling/unmarshaling of AdditionalProperties
@@ -142,8 +142,8 @@ func BundleCrd() *apiext_v1b1.CustomResourceDefinition {
 		Type:        "object",
 		Required:    []string{"name", "objectName"},
 		Properties: map[string]apiext_v1b1.JSONSchemaProps{
-			"name":       DNS_SUBDOMAIN,
-			"objectName": DNS_SUBDOMAIN,
+			"name":       dnsSubdomain,
+			"objectName": dnsSubdomain,
 			"spec": {
 				Type: "object",
 			},
@@ -159,7 +159,7 @@ func BundleCrd() *apiext_v1b1.CustomResourceDefinition {
 			"example": {
 				Description: "example of how we expect reference to resolve. Used for validation",
 			},
-			"modifier": DNS_SUBDOMAIN,
+			"modifier": dnsSubdomain,
 			"path": {
 				Description: "JSONPath expression used to extract data from resource",
 				Type:        "string",

--- a/pkg/resources/objects.go
+++ b/pkg/resources/objects.go
@@ -8,9 +8,9 @@ import (
 	"k8s.io/client-go/util/jsonpath"
 )
 
-// GetJsonPathString extracts the value from the object using given JsonPath template, in a string format
-func GetJsonPathString(obj interface{}, path string) (string, error) {
-	j := jsonpath.New("GetJsonPathString")
+// GetJSONPathString extracts the value from the object using given JsonPath template, in a string format
+func GetJSONPathString(obj interface{}, path string) (string, error) {
+	j := jsonpath.New("GetJSONPathString")
 	// If the key is missing, return an empty string without errors
 	j.AllowMissingKeys(true)
 	err := j.Parse(path)
@@ -25,9 +25,9 @@ func GetJsonPathString(obj interface{}, path string) (string, error) {
 	return buf.String(), nil
 }
 
-// GetJsonPathValue extracts the value from the object using given JsonPath template
-func GetJsonPathValue(obj interface{}, path string, allowMissingKeys bool) (interface{}, error) {
-	j := jsonpath.New("GetJsonPathValue")
+// GetJSONPathValue extracts the value from the object using given JsonPath template
+func GetJSONPathValue(obj interface{}, path string, allowMissingKeys bool) (interface{}, error) {
+	j := jsonpath.New("GetJSONPathValue")
 	// If the key is missing, return an empty string without errors
 	j.AllowMissingKeys(allowMissingKeys)
 	err := j.Parse(path)

--- a/pkg/resources/objects_test.go
+++ b/pkg/resources/objects_test.go
@@ -35,7 +35,7 @@ func TestGetJsonPathStringBundle(t *testing.T) {
 	unstructured := make(map[string]interface{})
 	err = json.Unmarshal(bytes, &unstructured)
 	require.NoError(t, err)
-	status, err := GetJsonPathString(unstructured, `{$.status.conditions[?(@.type=="Ready")].status}`)
+	status, err := GetJSONPathString(unstructured, `{$.status.conditions[?(@.type=="Ready")].status}`)
 	require.NoError(t, err)
 	assert.Equal(t, string(smith_v1.ConditionTrue), status)
 }
@@ -49,7 +49,7 @@ func TestGetJsonPathStringMissing(t *testing.T) {
 	unstructured := make(map[string]interface{})
 	err = json.Unmarshal(bytes, &unstructured)
 	require.NoError(t, err)
-	status, err := GetJsonPathString(unstructured, `{$.status.conditions[?(@.type=="Ready")].status}`)
+	status, err := GetJSONPathString(unstructured, `{$.status.conditions[?(@.type=="Ready")].status}`)
 	// Should return empty string without errors
 	require.NoError(t, err)
 	require.Equal(t, "", status)
@@ -73,6 +73,6 @@ func TestGetJsonPathStringInvalid(t *testing.T) {
 	err = json.Unmarshal(bytes, &unstructured)
 	require.NoError(t, err)
 	// Invalid JsonPath format: missing quotes around "Ready"
-	_, err = GetJsonPathString(unstructured, `{$.status.conditions[?(@.type==Ready)].status}`)
+	_, err = GetJSONPathString(unstructured, `{$.status.conditions[?(@.type==Ready)].status}`)
 	require.EqualError(t, err, "JsonPath execute error: unrecognized identifier Ready")
 }

--- a/pkg/store/bundle.go
+++ b/pkg/store/bundle.go
@@ -26,10 +26,10 @@ type ByNameStore interface {
 type BundleStore struct {
 	store            ByNameStore
 	bundleByIndex    func(indexName, indexKey string) ([]interface{}, error)
-	pluginContainers map[smith_v1.PluginName]plugin.PluginContainer
+	pluginContainers map[smith_v1.PluginName]plugin.Container
 }
 
-func NewBundle(bundleInf cache.SharedIndexInformer, store ByNameStore, pluginContainers map[smith_v1.PluginName]plugin.PluginContainer) (*BundleStore, error) {
+func NewBundle(bundleInf cache.SharedIndexInformer, store ByNameStore, pluginContainers map[smith_v1.PluginName]plugin.Container) (*BundleStore, error) {
 	bs := &BundleStore{
 		store:            store,
 		bundleByIndex:    bundleInf.GetIndexer().ByIndex,

--- a/pkg/store/catalog.go
+++ b/pkg/store/catalog.go
@@ -204,10 +204,9 @@ func (c *Catalog) getSchemaCache(plan *sc_v1b1.ClusterServicePlan, action planSc
 	defer c.schemasRWMutex.RUnlock()
 	if schemaWithRv, ok := c.schemas[key]; ok && schemaWithRv.resourceVersion == plan.ResourceVersion {
 		return schemaWithRv.schema, true
-	} else {
-		// nil is a valid entry in the cache
-		return nil, false
 	}
+	// nil is a valid entry in the cache
+	return nil, false
 }
 
 func (c *Catalog) setSchemaCache(plan *sc_v1b1.ClusterServicePlan, action planSchemaAction, schema *gojsonschema.Schema) {

--- a/pkg/store/multi.go
+++ b/pkg/store/multi.go
@@ -10,7 +10,7 @@ import (
 )
 
 const (
-	ByNamespaceAndControllerUidIndex = "NamespaceUidIndex"
+	ByNamespaceAndControllerUIDIndex = "NamespaceUidIndex"
 )
 
 type Multi struct {
@@ -31,11 +31,11 @@ func (s *Multi) AddInformer(gvk schema.GroupVersionKind, informer cache.SharedIn
 	if _, ok := s.informers[gvk]; ok {
 		return errors.New("informer is already registered")
 	}
-	f := informer.GetIndexer().GetIndexers()[ByNamespaceAndControllerUidIndex]
+	f := informer.GetIndexer().GetIndexers()[ByNamespaceAndControllerUIDIndex]
 	if f == nil {
 		// Informer does not have this index yet i.e. this is the first/sole multistore it is added to.
 		err := informer.AddIndexers(cache.Indexers{
-			ByNamespaceAndControllerUidIndex: byNamespaceAndControllerUidIndex,
+			ByNamespaceAndControllerUIDIndex: byNamespaceAndControllerUIDIndex,
 		})
 		if err != nil {
 			return errors.WithStack(err)
@@ -47,9 +47,9 @@ func (s *Multi) AddInformer(gvk schema.GroupVersionKind, informer cache.SharedIn
 
 func (s *Multi) ObjectsControlledBy(namespace string, uid types.UID) ([]runtime.Object, error) {
 	var result []runtime.Object
-	indexKey := ByNamespaceAndControllerUidIndexKey(namespace, uid)
+	indexKey := ByNamespaceAndControllerUIDIndexKey(namespace, uid)
 	for gvk, inf := range s.GetInformers() {
-		objs, err := inf.GetIndexer().ByIndex(ByNamespaceAndControllerUidIndex, indexKey)
+		objs, err := inf.GetIndexer().ByIndex(ByNamespaceAndControllerUIDIndex, indexKey)
 		if err != nil {
 			return nil, errors.Wrapf(err, "failed to get objects for bundle from %s informer", gvk)
 		}
@@ -62,19 +62,19 @@ func (s *Multi) ObjectsControlledBy(namespace string, uid types.UID) ([]runtime.
 	return result, nil
 }
 
-func byNamespaceAndControllerUidIndex(obj interface{}) ([]string, error) {
+func byNamespaceAndControllerUIDIndex(obj interface{}) ([]string, error) {
 	if key, ok := obj.(cache.ExplicitKey); ok {
 		return []string{string(key)}, nil
 	}
 	m := obj.(meta_v1.Object)
 	ref := meta_v1.GetControllerOf(m)
 	if ref != nil {
-		return []string{ByNamespaceAndControllerUidIndexKey(m.GetNamespace(), ref.UID)}, nil
+		return []string{ByNamespaceAndControllerUIDIndexKey(m.GetNamespace(), ref.UID)}, nil
 	}
 	return nil, nil
 }
 
-func ByNamespaceAndControllerUidIndexKey(namespace string, uid types.UID) string {
+func ByNamespaceAndControllerUIDIndexKey(namespace string, uid types.UID) string {
 	if namespace == meta_v1.NamespaceNone {
 		return string(uid)
 	}


### PR DESCRIPTION
- switch to using gopkg.in/alecthomas/gometalinter.v2 (insulate us slightly from upstream changes)
- enable golint linter, but exclude warnings about comments
- address golint warnings: initialisms in identifiers, unhandled errors, exported identifiers that stutter, underscores in variable names, ALL_CAPS variables, redundant `else`
- where such warnings could not be addressed without breaking compatibility, I left behind a `// TODO: smith.v2: ...` comment, so we can come back to these when we break compatibility for other reasons, if we like