### PR TITLE
Added prometheus metrics around bundle condition transitions

### DIFF
--- a/cmd/smith/app/BUILD.bazel
+++ b/cmd/smith/app/BUILD.bazel
@@ -23,6 +23,7 @@ go_library(
         "//vendor/github.com/kubernetes-incubator/service-catalog/pkg/client/clientset_generated/clientset:go_default_library",
         "//vendor/github.com/kubernetes-incubator/service-catalog/pkg/client/informers_generated/externalversions/servicecatalog/v1beta1:go_default_library",
         "//vendor/github.com/pkg/errors:go_default_library",
+        "//vendor/github.com/prometheus/client_golang/prometheus:go_default_library",
         "//vendor/k8s.io/api/apps/v1:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/api/extensions/v1beta1:go_default_library",

--- a/cmd/smith/app/bundle_controller.go
+++ b/cmd/smith/app/bundle_controller.go
@@ -181,7 +181,7 @@ func (c *BundleControllerConstructor) New(config *ctrl.Config, cctx *ctrl.Contex
 	bundleResourceTransitionCounter := prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: config.AppName,
-			Name:      "bundle_transitions",
+			Name:      "bundle_resource_transitions",
 			Help:      "Records the number of times a Bundle transitions into a new condition",
 		},
 		[]string{"namespace", "name", "resource", "type", "reason"},

--- a/cmd/smith/app/bundle_controller.go
+++ b/cmd/smith/app/bundle_controller.go
@@ -21,6 +21,7 @@ import (
 	scClientset "github.com/kubernetes-incubator/service-catalog/pkg/client/clientset_generated/clientset"
 	sc_v1b1inf "github.com/kubernetes-incubator/service-catalog/pkg/client/informers_generated/externalversions/servicecatalog/v1beta1"
 	"github.com/pkg/errors"
+	"github.com/prometheus/client_golang/prometheus"
 	apps_v1 "k8s.io/api/apps/v1"
 	core_v1 "k8s.io/api/core/v1"
 	ext_v1b1 "k8s.io/api/extensions/v1beta1"
@@ -169,22 +170,49 @@ func (c *BundleControllerConstructor) New(config *ctrl.Config, cctx *ctrl.Contex
 		}
 	}
 
+	bundleTransitionCounter := prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: config.AppName,
+			Name:      "bundle_transitions",
+			Help:      "Records the number of times a Bundle transitions into a new condition",
+		},
+		[]string{"namespace", "name", "type", "reason"},
+	)
+	bundleResourceTransitionCounter := prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: config.AppName,
+			Name:      "bundle_transitions",
+			Help:      "Records the number of times a Bundle transitions into a new condition",
+		},
+		[]string{"namespace", "name", "resource", "type", "reason"},
+	)
+
+	allMetrics := []prometheus.Collector{bundleTransitionCounter, bundleResourceTransitionCounter}
+	for _, metric := range allMetrics {
+		err = config.Registry.Register(metric)
+		if err != nil {
+			return nil, errors.WithStack(err)
+		}
+	}
+
 	// Controller
 	cntrlr := &bundlec.Controller{
-		Logger:           config.Logger,
-		ReadyForWork:     cctx.ReadyForWork,
-		BundleClient:     smithClient.SmithV1(),
-		BundleStore:      bs,
-		SmartClient:      smartClient,
-		Rc:               rc,
-		Store:            multiStore,
-		SpecCheck:        specCheck,
-		WorkQueue:        cctx.WorkQueue,
-		CrdResyncPeriod:  config.ResyncPeriod,
-		Namespace:        config.Namespace,
-		PluginContainers: pluginContainers,
-		Scheme:           scheme,
-		Catalog:          catalog,
+		Logger:                          config.Logger,
+		ReadyForWork:                    cctx.ReadyForWork,
+		BundleClient:                    smithClient.SmithV1(),
+		BundleStore:                     bs,
+		SmartClient:                     smartClient,
+		Rc:                              rc,
+		Store:                           multiStore,
+		SpecCheck:                       specCheck,
+		WorkQueue:                       cctx.WorkQueue,
+		CrdResyncPeriod:                 config.ResyncPeriod,
+		Namespace:                       config.Namespace,
+		PluginContainers:                pluginContainers,
+		Scheme:                          scheme,
+		Catalog:                         catalog,
+		BundleTransitionCounter:         bundleTransitionCounter,
+		BundleResourceTransitionCounter: bundleResourceTransitionCounter,
 	}
 	cntrlr.Prepare(crdInf, resourceInfs)
 

--- a/pkg/controller/bundlec/BUILD.bazel
+++ b/pkg/controller/bundlec/BUILD.bazel
@@ -30,6 +30,7 @@ go_library(
         "//vendor/github.com/atlassian/ctrl/logz:go_default_library",
         "//vendor/github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog/v1beta1:go_default_library",
         "//vendor/github.com/pkg/errors:go_default_library",
+        "//vendor/github.com/prometheus/client_golang/prometheus:go_default_library",
         "//vendor/go.uber.org/zap:go_default_library",
         "//vendor/golang.org/x/crypto/bcrypt:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",

--- a/pkg/controller/bundlec/bundle_sync_task.go
+++ b/pkg/controller/bundlec/bundle_sync_task.go
@@ -583,6 +583,11 @@ func (st *bundleSyncTask) updateBundleCondition(b *smith_v1.Bundle, condition *s
 
 	if oldCondition == nil {
 		// New resource condition
+		if condition.Status == smith_v1.ConditionTrue {
+			st.bundleTransitionCounter.
+				WithLabelValues(st.bundle.GetNamespace(), st.bundle.GetName(), string(condition.Type), condition.Reason).
+				Inc()
+		}
 		return true
 	}
 
@@ -621,6 +626,11 @@ func (st *bundleSyncTask) updateResourceCondition(b *smith_v1.Bundle, resName sm
 
 	if status == nil {
 		// No status for this resource, hence it's a new resource condition
+		if condition.Status == smith_v1.ConditionTrue {
+			st.bundleResourceTransitionCounter.
+				WithLabelValues(st.bundle.GetNamespace(), st.bundle.GetName(), string(resName), string(condition.Type), condition.Reason).
+				Inc()
+		}
 		return true
 	}
 
@@ -629,6 +639,11 @@ func (st *bundleSyncTask) updateResourceCondition(b *smith_v1.Bundle, resName sm
 
 	if oldCondition == nil {
 		// New resource condition
+		if condition.Status == smith_v1.ConditionTrue {
+			st.bundleResourceTransitionCounter.
+				WithLabelValues(st.bundle.GetNamespace(), st.bundle.GetName(), string(resName), string(condition.Type), condition.Reason).
+				Inc()
+		}
 		return true
 	}
 

--- a/pkg/controller/bundlec/controller.go
+++ b/pkg/controller/bundlec/controller.go
@@ -11,6 +11,7 @@ import (
 	smithClient_v1 "github.com/atlassian/smith/pkg/client/clientset_generated/clientset/typed/smith/v1"
 	"github.com/atlassian/smith/pkg/plugin"
 	"github.com/atlassian/smith/pkg/store"
+	"github.com/prometheus/client_golang/prometheus"
 	"go.uber.org/zap"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -49,6 +50,10 @@ type Controller struct {
 	Scheme           *runtime.Scheme
 
 	Catalog *store.Catalog
+
+	// Metrics
+	BundleTransitionCounter         *prometheus.CounterVec
+	BundleResourceTransitionCounter *prometheus.CounterVec
 }
 
 // Prepare prepares the controller to be run.

--- a/pkg/controller/bundlec/controller_worker.go
+++ b/pkg/controller/bundlec/controller_worker.go
@@ -13,16 +13,18 @@ func (c *Controller) Process(pctx *ctrl.ProcessContext) (retriableRet bool, errR
 // ProcessBundle is only visible for testing purposes. Should not be called directly.
 func (c *Controller) ProcessBundle(logger *zap.Logger, bundle *smith_v1.Bundle) (retriableRet bool, errRet error) {
 	st := bundleSyncTask{
-		logger:           logger,
-		bundleClient:     c.BundleClient,
-		smartClient:      c.SmartClient,
-		rc:               c.Rc,
-		store:            c.Store,
-		specCheck:        c.SpecCheck,
-		bundle:           bundle,
-		pluginContainers: c.PluginContainers,
-		scheme:           c.Scheme,
-		catalog:          c.Catalog,
+		logger:                          logger,
+		bundleClient:                    c.BundleClient,
+		smartClient:                     c.SmartClient,
+		rc:                              c.Rc,
+		store:                           c.Store,
+		specCheck:                       c.SpecCheck,
+		bundle:                          bundle,
+		pluginContainers:                c.PluginContainers,
+		scheme:                          c.Scheme,
+		catalog:                         c.Catalog,
+		bundleTransitionCounter:         c.BundleTransitionCounter,
+		bundleResourceTransitionCounter: c.BundleResourceTransitionCounter,
 	}
 
 	var retriable bool


### PR DESCRIPTION
This adds a bunch of metrics into prometheus endpoint about bundle transitions, which would be useful for alerting purposes.

Also proposal for the same PR: How about expanding the error enums?

E.g. for resources we often just spit out the error but it would be useful to categorize if the Spec was wrong or service catalog didn't respond or if the resource couldn't be created.

```
	spec, err := st.evalSpec(res, actual)
	if err != nil {
		return resourceInfo{
			status: resourceStatusError{
 /// this thing could have something like "ResourceSpecInvalidError"?
				err: err,
			},
		}

```