### PR TITLE
Add missing error logging

### DIFF
--- a/pkg/controller/bundlec/bundle_sync_task.go
+++ b/pkg/controller/bundlec/bundle_sync_task.go
@@ -408,6 +408,8 @@ func (st *bundleSyncTask) handleProcessResult(retriable bool, processErr error) 
 		if processErr == nil {
 			processErr = ex
 			retriable = true
+		} else {
+			st.logger.Error("Error updating Bundle", zap.Error(ex))
 		}
 	}
 


### PR DESCRIPTION
An RBAC issues was not visible because there was no logging and debugging it was a pita.