### PR TITLE
Go imports

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -4,8 +4,8 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
     name = "io_bazel_rules_go",
-    sha256 = "97cf62bdef33519412167fd1e4b0810a318a7c234f5f8dc4f53e2da86241c492",
-    urls = ["https://github.com/bazelbuild/rules_go/releases/download/0.15.3/rules_go-0.15.3.tar.gz"],
+    sha256 = "7519e9e1c716ae3c05bd2d984a42c3b02e690c5df728dc0a84b23f90c355c5a1",
+    urls = ["https://github.com/bazelbuild/rules_go/releases/download/0.15.4/rules_go-0.15.4.tar.gz"],
 )
 
 http_archive(
@@ -30,9 +30,9 @@ http_archive(
 
 http_archive(
     name = "com_github_atlassian_bazel_tools",
-    sha256 = "15b3c0b43f29f802d4ec06ee2b8e175fac08c0e93f91950830e5ed3b4171dd3a",
-    strip_prefix = "bazel-tools-03b64959dd47b6d904de72cfdca5eaa3a3945bf1",
-    urls = ["https://github.com/atlassian/bazel-tools/archive/03b64959dd47b6d904de72cfdca5eaa3a3945bf1.tar.gz"],
+    sha256 = "91208f44bbc6ac9773f34b624e25c90216bdf35e533ec9caa6fd60e7d33b0de2",
+    strip_prefix = "bazel-tools-333dc4fc3538c407a8af095ad35bfb83e26ab853",
+    urls = ["https://github.com/atlassian/bazel-tools/archive/333dc4fc3538c407a8af095ad35bfb83e26ab853.tar.gz"],
 )
 
 http_archive(
@@ -56,6 +56,10 @@ load("@com_github_atlassian_bazel_tools//buildozer:deps.bzl", "buildozer_depende
 load("@com_github_atlassian_bazel_tools//goimports:deps.bzl", "goimports_dependencies")
 load("@com_github_atlassian_bazel_tools//gometalinter:deps.bzl", "gometalinter_dependencies")
 
+# Brings in newer version of org_golang_x_tools which is what provides the goimpotrs binary.
+# Should be before go_rules_dependencies()/etc which briging in older version.
+goimports_dependencies()
+
 go_rules_dependencies()
 
 go_register_toolchains()
@@ -69,7 +73,5 @@ go_image_repositories()
 buildifier_dependencies()
 
 buildozer_dependencies()
-
-goimports_dependencies()
 
 gometalinter_dependencies()

--- a/examples/sleeper/client.go
+++ b/examples/sleeper/client.go
@@ -3,7 +3,6 @@ package sleeper
 import (
 	"github.com/atlassian/smith"
 	sleeper_v1 "github.com/atlassian/smith/examples/sleeper/pkg/apis/sleeper/v1"
-
 	core_v1 "k8s.io/api/core/v1"
 	apiext_v1b1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/examples/sleeper/pkg/apis/sleeper/v1/types_test.go
+++ b/examples/sleeper/pkg/apis/sleeper/v1/types_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 
 	"github.com/atlassian/smith/pkg/resources"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/it/resource_deletion_test.go
+++ b/it/resource_deletion_test.go
@@ -4,13 +4,12 @@ import (
 	"context"
 	"testing"
 
+	"github.com/ash2k/stager"
 	cond_v1 "github.com/atlassian/ctrl/apis/condition/v1"
 	"github.com/atlassian/smith/examples/sleeper"
 	sleeper_v1 "github.com/atlassian/smith/examples/sleeper/pkg/apis/sleeper/v1"
 	smith_v1 "github.com/atlassian/smith/pkg/apis/smith/v1"
 	smith_testing "github.com/atlassian/smith/pkg/util/testing"
-
-	"github.com/ash2k/stager"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	core_v1 "k8s.io/api/core/v1"

--- a/it/sc/service_catalog_test.go
+++ b/it/sc/service_catalog_test.go
@@ -6,10 +6,9 @@ import (
 
 	"github.com/atlassian/smith/it"
 	smith_v1 "github.com/atlassian/smith/pkg/apis/smith/v1"
-	"k8s.io/apimachinery/pkg/runtime"
-
 	sc_v1b1 "github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog/v1beta1"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 )
 
 func TestServiceCatalog(t *testing.T) {

--- a/pkg/apis/smith/v1/register.go
+++ b/pkg/apis/smith/v1/register.go
@@ -2,7 +2,6 @@ package v1
 
 import (
 	"github.com/atlassian/smith/pkg/apis/smith"
-
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"

--- a/pkg/controller/bundlec/controller_worker_test.go
+++ b/pkg/controller/bundlec/controller_worker_test.go
@@ -5,7 +5,6 @@ import (
 
 	smith_v1 "github.com/atlassian/smith/pkg/apis/smith/v1"
 	"github.com/atlassian/smith/pkg/util/graph"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/pkg/controller/bundlec/service_instance.go
+++ b/pkg/controller/bundlec/service_instance.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/atlassian/smith"
 	"github.com/atlassian/smith/pkg/util"
-
 	sc_v1b1 "github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog/v1beta1"
 	"github.com/pkg/errors"
 	"golang.org/x/crypto/bcrypt"

--- a/pkg/controller/bundlec/spec_processor_test.go
+++ b/pkg/controller/bundlec/spec_processor_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	smith_v1 "github.com/atlassian/smith/pkg/apis/smith/v1"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	core_v1 "k8s.io/api/core/v1"

--- a/pkg/controller/bundlec/types.go
+++ b/pkg/controller/bundlec/types.go
@@ -2,7 +2,6 @@ package bundlec
 
 import (
 	smith_v1 "github.com/atlassian/smith/pkg/apis/smith/v1"
-
 	apiext_v1b1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"

--- a/pkg/plugin/types.go
+++ b/pkg/plugin/types.go
@@ -6,7 +6,6 @@ package plugin
 
 import (
 	smith_v1 "github.com/atlassian/smith/pkg/apis/smith/v1"
-
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )

--- a/pkg/readychecker/ready_checker.go
+++ b/pkg/readychecker/ready_checker.go
@@ -3,7 +3,6 @@ package readychecker
 import (
 	"github.com/atlassian/smith"
 	"github.com/atlassian/smith/pkg/resources"
-
 	"github.com/pkg/errors"
 	apiext_v1b1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"

--- a/pkg/readychecker/types/built_in.go
+++ b/pkg/readychecker/types/built_in.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/atlassian/smith/pkg/readychecker"
 	"github.com/atlassian/smith/pkg/util"
-
 	sc_v1b1 "github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog/v1beta1"
 	"github.com/pkg/errors"
 	apps_v1 "k8s.io/api/apps/v1"

--- a/pkg/store/bundle.go
+++ b/pkg/store/bundle.go
@@ -6,7 +6,6 @@ import (
 
 	smith_v1 "github.com/atlassian/smith/pkg/apis/smith/v1"
 	"github.com/atlassian/smith/pkg/plugin"
-
 	apiext_v1b1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"


### PR DESCRIPTION
Update bazel-tools dependency to pick up new goimports. See https://github.com/atlassian/bazel-tools/pull/25. Second commit applies new formatting. Yay!