### PR TITLE
Reduce errors in precheck

### DIFF
--- a/pkg/controller/bundlec/bundle_sync_task.go
+++ b/pkg/controller/bundlec/bundle_sync_task.go
@@ -564,8 +564,10 @@ func (st *bundleSyncTask) resourceConditions(res smith_v1.Resource) (
 			blockedCond.Message = fmt.Sprintf("Not ready: %q", resStatus.dependencies)
 		case resourceStatusInProgress:
 			inProgressCond.Status = cond_v1.ConditionTrue
+			inProgressCond.Message = resStatus.message
 		case resourceStatusReady:
 			readyCond.Status = cond_v1.ConditionTrue
+			readyCond.Message = resStatus.message
 		case resourceStatusError:
 			errorCond.Status = cond_v1.ConditionTrue
 			errorCond.Message = resStatus.err.Error()

--- a/pkg/controller/bundlec/resource_sync_task.go
+++ b/pkg/controller/bundlec/resource_sync_task.go
@@ -408,7 +408,10 @@ func (st *resourceSyncTask) prevalidate(res *smith_v1.Resource) resourceStatus {
 		}
 		pluginContainer, ok := st.pluginContainers[res.Spec.Plugin.Name]
 		if !ok {
-			return resourceStatusError{err: errors.Errorf("plugin %q does not exist", res.Spec.Plugin.Name)}
+			return resourceStatusError{
+				err:             errors.Errorf("plugin %q does not exist", res.Spec.Plugin.Name),
+				isExternalError: true,
+			}
 		}
 		validationResult, err := pluginContainer.ValidateSpec(res.Spec.Plugin.Spec)
 		if err != nil {

--- a/pkg/controller/bundlec/resource_sync_task.go
+++ b/pkg/controller/bundlec/resource_sync_task.go
@@ -43,7 +43,7 @@ type resourceStatusDependenciesNotReady struct {
 
 // resourceStatusInProgress means resource is being processed by its controller.
 type resourceStatusInProgress struct {
-	details string
+	message string
 }
 
 // resourceStatusReady means resource is ready.
@@ -192,7 +192,9 @@ func (st *resourceSyncTask) processResource(res *smith_v1.Resource) resourceInfo
 	case statuschecker.ObjectStatusInProgress:
 		return resourceInfo{
 			actual: resUpdated,
-			status: resourceStatusInProgress{},
+			status: resourceStatusInProgress{
+				message: s.Message,
+			},
 		}
 	case statuschecker.ObjectStatusError:
 		return resourceInfo{
@@ -223,8 +225,10 @@ func (st *resourceSyncTask) processResource(res *smith_v1.Resource) resourceInfo
 		}
 
 		return resourceInfo{
-			actual:               resUpdated,
-			status:               resourceStatusReady{},
+			actual: resUpdated,
+			status: resourceStatusReady{
+				message: s.Message,
+			},
 			serviceBindingSecret: bindingSecret,
 		}
 	default:

--- a/pkg/controller/bundlec/resource_sync_task.go
+++ b/pkg/controller/bundlec/resource_sync_task.go
@@ -43,16 +43,19 @@ type resourceStatusDependenciesNotReady struct {
 
 // resourceStatusInProgress means resource is being processed by its controller.
 type resourceStatusInProgress struct {
+	details string
 }
 
 // resourceStatusReady means resource is ready.
 type resourceStatusReady struct {
+	message string
 }
 
 // resourceStatusError means there was an error processing this resource.
 type resourceStatusError struct {
 	err              error
 	isRetriableError bool
+	isExternalError  bool
 }
 
 func (r resourceStatusReady) StatusType() ResourceStatusType {
@@ -81,11 +84,11 @@ func (ri *resourceInfo) isReady() bool {
 	return ok
 }
 
-func (ri *resourceInfo) fetchError() (bool, error) {
+func (ri *resourceInfo) fetchError() *resourceStatusError {
 	if rse, ok := ri.status.(resourceStatusError); ok {
-		return rse.isRetriableError, rse.err
+		return &rse
 	}
-	return false, nil
+	return nil
 }
 
 type resourceSyncTask struct {
@@ -184,18 +187,7 @@ func (st *resourceSyncTask) processResource(res *smith_v1.Resource) resourceInfo
 	}
 
 	// Check if resource is ready
-	statusResult, err := st.checker.CheckStatus(resUpdated)
-	if err != nil {
-		// This represents an internal error (something wrong with smith)
-		// and should probably be handled differently.
-		return resourceInfo{
-			actual: resUpdated,
-			status: resourceStatusError{
-				err:              err,
-				isRetriableError: false,
-			},
-		}
-	}
+	statusResult := st.checker.CheckStatus(resUpdated)
 	switch s := statusResult.(type) {
 	case statuschecker.ObjectStatusInProgress:
 		return resourceInfo{
@@ -208,6 +200,7 @@ func (st *resourceSyncTask) processResource(res *smith_v1.Resource) resourceInfo
 			status: resourceStatusError{
 				err:              s.Error,
 				isRetriableError: s.RetriableError,
+				isExternalError:  s.ExternalError,
 			},
 		}
 	case statuschecker.ObjectStatusUnknown:
@@ -613,7 +606,7 @@ func (st *resourceSyncTask) createResource(resClient dynamic.ResourceInterface, 
 		return nil, false, errors.Wrap(err, "object specification pre-processing failed")
 	}
 	gvk := spec.GroupVersionKind()
-	st.logger.Info("Object not found, creating", ctrlLogz.ObjectGk(gvk.GroupKind()), ctrlLogz.Object(spec))
+	st.logger.Debug("Object not found, creating", ctrlLogz.ObjectGk(gvk.GroupKind()), ctrlLogz.Object(spec))
 	response, err := resClient.Create(spec, meta_v1.CreateOptions{})
 	if err == nil {
 		st.logger.Info("Object created", ctrlLogz.ObjectGk(gvk.GroupKind()), ctrlLogz.Object(spec))
@@ -630,14 +623,14 @@ func (st *resourceSyncTask) createResource(resClient dynamic.ResourceInterface, 
 
 // Mutates spec and actual.
 func (st *resourceSyncTask) updateResource(resClient dynamic.ResourceInterface, spec *unstructured.Unstructured, actual runtime.Object) (actualRet *unstructured.Unstructured, retriableError bool, e error) {
-	st.logger.Info("Object found, checking spec", ctrlLogz.ObjectGk(spec.GroupVersionKind().GroupKind()), ctrlLogz.Object(spec))
+	st.logger.Debug("Object found, checking spec", ctrlLogz.ObjectGk(spec.GroupVersionKind().GroupKind()), ctrlLogz.Object(spec))
 	// Compare spec and existing resource
 	updated, match, difference, err := st.specCheck.CompareActualVsSpec(st.logger, spec, actual)
 	if err != nil {
 		return nil, false, errors.Wrap(err, "specification check failed")
 	}
 	if match {
-		st.logger.Info("Object has correct spec", ctrlLogz.Object(spec))
+		st.logger.Debug("Object has correct spec", ctrlLogz.Object(spec))
 		return updated, false, nil
 	}
 	st.logger.Sugar().Infof("Objects are different (`a` is specification and `b` is the actual object): %s", difference)

--- a/pkg/controller/bundlec/resource_sync_task.go
+++ b/pkg/controller/bundlec/resource_sync_task.go
@@ -17,6 +17,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/diff"
+	k8s_errors "k8s.io/apimachinery/pkg/util/errors"
 	k8s_json "k8s.io/apimachinery/pkg/util/json"
 	"k8s.io/client-go/dynamic"
 )
@@ -113,11 +114,10 @@ func (st *resourceSyncTask) processResource(res *smith_v1.Resource) resourceInfo
 	// it before we start processing the bundle, both to fail faster and avoid
 	// some unnecessary schema validations (particularly if we want to cache
 	// entire bundle prevalidation results rather than specific validations).
-	if err := st.prevalidate(res); err != nil {
+	status := st.prevalidate(res)
+	if status != nil {
 		return resourceInfo{
-			status: resourceStatusError{
-				err: err,
-			},
+			status: status,
 		}
 	}
 
@@ -330,7 +330,7 @@ func (st *resourceSyncTask) getActualObject(res *smith_v1.Resource) (runtime.Obj
 }
 
 // prevalidate does as much validation as possible before doing any real work.
-func (st *resourceSyncTask) prevalidate(res *smith_v1.Resource) error {
+func (st *resourceSyncTask) prevalidate(res *smith_v1.Resource) resourceStatus {
 	sp, err := newExamplesSpec(res.References)
 	if err != nil {
 		if isNoExampleError(errors.Cause(err)) {
@@ -340,7 +340,7 @@ func (st *resourceSyncTask) prevalidate(res *smith_v1.Resource) error {
 			st.logger.Debug("Not validating against schema due to missing examples", zap.Error(err))
 			return nil
 		}
-		return err
+		return resourceStatusError{err: err}
 	}
 	serviceInstanceGvk := sc_v1b1.SchemeGroupVersion.WithKind("ServiceInstance")
 	res = res.DeepCopy() // Spec processor mutates in place
@@ -353,7 +353,7 @@ func (st *resourceSyncTask) prevalidate(res *smith_v1.Resource) error {
 			}
 			actual, err := st.scheme.ConvertToVersion(res.Spec.Object, serviceInstanceGvk.GroupVersion())
 			if err != nil {
-				return errors.WithStack(err)
+				return resourceStatusError{err: errors.WithStack(err)}
 			}
 			serviceInstance := actual.(*sc_v1b1.ServiceInstance)
 
@@ -365,22 +365,34 @@ func (st *resourceSyncTask) prevalidate(res *smith_v1.Resource) error {
 			if serviceInstance.Spec.Parameters != nil {
 				var parameters map[string]interface{}
 				if err = k8s_json.Unmarshal(serviceInstance.Spec.Parameters.Raw, &parameters); err != nil {
-					return errors.Wrap(err, "unable to unmarshal ServiceInstance resource parameters as object")
+					return resourceStatusError{
+						err:             errors.Wrap(err, "unable to unmarshal ServiceInstance resource parameters as object"),
+						isExternalError: true,
+					}
 				}
 
 				if err = sp.ProcessObject(parameters); err != nil {
-					return err
+					return resourceStatusError{
+						err:             err,
+						isExternalError: true,
+					}
 				}
 
 				serviceInstance.Spec.Parameters.Raw, err = k8s_json.Marshal(parameters)
 				if err != nil {
-					return errors.WithStack(err)
+					return resourceStatusError{err: errors.WithStack(err)}
 				}
 			}
 
-			err = st.catalog.ValidateServiceInstanceSpec(&serviceInstance.Spec)
+			validationResult, err := st.catalog.ValidateServiceInstanceSpec(&serviceInstance.Spec)
 			if err != nil {
-				return errors.WithStack(err)
+				return resourceStatusError{err: err}
+			}
+			if len(validationResult.Errors) > 0 {
+				return resourceStatusError{
+					err:             errors.Wrap(k8s_errors.NewAggregate(validationResult.Errors), "spec failed validation against schema"),
+					isExternalError: true,
+				}
 			}
 		}
 		// TODO validate service binding parameters
@@ -388,16 +400,25 @@ func (st *resourceSyncTask) prevalidate(res *smith_v1.Resource) error {
 	} else if res.Spec.Plugin != nil {
 		if res.Spec.Plugin.Spec != nil {
 			if err := sp.ProcessObject(res.Spec.Plugin.Spec); err != nil {
-				return err
+				return resourceStatusError{
+					err:             err,
+					isExternalError: true,
+				}
 			}
 		}
 		pluginContainer, ok := st.pluginContainers[res.Spec.Plugin.Name]
 		if !ok {
-			return errors.Errorf("plugin %q does not exist", res.Spec.Plugin.Name)
+			return resourceStatusError{err: errors.Errorf("plugin %q does not exist", res.Spec.Plugin.Name)}
 		}
-		err := pluginContainer.ValidateSpec(res.Spec.Plugin.Spec)
+		validationResult, err := pluginContainer.ValidateSpec(res.Spec.Plugin.Spec)
 		if err != nil {
-			return errors.Wrap(err, "invalid spec")
+			return resourceStatusError{err: err}
+		}
+		if len(validationResult.Errors) > 0 {
+			return resourceStatusError{
+				err:             errors.Wrap(k8s_errors.NewAggregate(validationResult.Errors), "spec failed validation against schema"),
+				isExternalError: true,
+			}
 		}
 	}
 
@@ -497,9 +518,12 @@ func (st *resourceSyncTask) evalPluginSpec(res *smith_v1.Resource, actual runtim
 	if !ok {
 		return nil, errors.Errorf("no such plugin %q", res.Spec.Plugin.Name)
 	}
-	err := pluginContainer.ValidateSpec(res.Spec.Plugin.Spec)
+	validationResult, err := pluginContainer.ValidateSpec(res.Spec.Plugin.Spec)
 	if err != nil {
-		return nil, errors.Wrapf(err, "plugin %q has invalid spec", res.Spec.Plugin.Name)
+		return nil, err
+	}
+	if len(validationResult.Errors) > 0 {
+		return nil, errors.Wrap(k8s_errors.NewAggregate(validationResult.Errors), "spec failed validation against schema")
 	}
 
 	// validate above should guarantee that our plugin is there

--- a/pkg/controller/bundlec_test/plugin_schema_invalid_test.go
+++ b/pkg/controller/bundlec_test/plugin_schema_invalid_test.go
@@ -59,7 +59,7 @@ func TestPluginSchemaInvalid(t *testing.T) {
 			resCond := smith_testing.AssertResourceCondition(t, updateBundle, resP1, smith_v1.ResourceError, cond_v1.ConditionTrue)
 			if resCond != nil {
 				assert.Equal(t, smith_v1.ResourceReasonTerminalError, resCond.Reason)
-				assert.Equal(t, "invalid spec: spec failed validation against schema: p1: Invalid type. Expected: string, given: null", resCond.Message)
+				assert.Equal(t, "spec failed validation against schema: p1: Invalid type. Expected: string, given: null", resCond.Message)
 			}
 		},
 	}

--- a/pkg/controller/bundlec_test/schema_early_validation_test.go
+++ b/pkg/controller/bundlec_test/schema_early_validation_test.go
@@ -200,7 +200,7 @@ func TestSchemaEarlyValidation(t *testing.T) {
 			resCond := smith_testing.AssertResourceCondition(t, updateBundle, resPWithDefaults, smith_v1.ResourceError, cond_v1.ConditionTrue)
 			if resCond != nil {
 				assert.Equal(t, smith_v1.ResourceReasonTerminalError, resCond.Reason)
-				assert.Equal(t, "invalid spec: spec failed validation against schema: p1: Invalid type. Expected: string, given: boolean", resCond.Message)
+				assert.Equal(t, "spec failed validation against schema: p1: Invalid type. Expected: string, given: boolean", resCond.Message)
 			}
 			resCond = smith_testing.AssertResourceCondition(t, updateBundle, resSiWithDefaults, smith_v1.ResourceError, cond_v1.ConditionTrue)
 			if resCond != nil {

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -1,8 +1,6 @@
 package plugin
 
 import (
-	"strings"
-
 	"github.com/pkg/errors"
 	"github.com/xeipuuv/gojsonschema"
 )
@@ -10,6 +8,10 @@ import (
 type Container struct {
 	Plugin Plugin
 	schema *gojsonschema.Schema
+}
+
+type validationResult struct {
+	Errors []error
 }
 
 func NewContainer(newPlugin NewFunc) (Container, error) {
@@ -32,27 +34,26 @@ func NewContainer(newPlugin NewFunc) (Container, error) {
 	}, nil
 }
 
-func (pc *Container) ValidateSpec(pluginSpec map[string]interface{}) error {
+func (pc *Container) ValidateSpec(pluginSpec map[string]interface{}) (validationResult, error) {
 	if pc.schema == nil {
-		return nil
+		return validationResult{}, nil
 	}
 
-	validationResult, err := pc.schema.Validate(gojsonschema.NewGoLoader(pluginSpec))
+	result, err := pc.schema.Validate(gojsonschema.NewGoLoader(pluginSpec))
 	if err != nil {
-		return errors.Wrap(err, "error validating plugin spec")
+		return validationResult{}, errors.Wrap(err, "error validating plugin spec")
 	}
 
-	if !validationResult.Valid() {
-		validationErrors := validationResult.Errors()
-		msgs := make([]string, 0, len(validationErrors))
+	if !result.Valid() {
+		validationErrors := result.Errors()
+		errs := make([]error, 0, len(validationErrors))
 
 		for _, validationErr := range validationErrors {
-			msgs = append(msgs, validationErr.String())
+			errs = append(errs, errors.New(validationErr.String()))
 		}
 
-		return errors.Errorf("spec failed validation against schema: %s",
-			strings.Join(msgs, ", "))
+		return validationResult{errs}, nil
 	}
 
-	return nil
+	return validationResult{}, nil
 }

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -10,7 +10,7 @@ type Container struct {
 	schema *gojsonschema.Schema
 }
 
-type validationResult struct {
+type ValidationResult struct {
 	Errors []error
 }
 
@@ -34,14 +34,14 @@ func NewContainer(newPlugin NewFunc) (Container, error) {
 	}, nil
 }
 
-func (pc *Container) ValidateSpec(pluginSpec map[string]interface{}) (validationResult, error) {
+func (pc *Container) ValidateSpec(pluginSpec map[string]interface{}) (ValidationResult, error) {
 	if pc.schema == nil {
-		return validationResult{}, nil
+		return ValidationResult{}, nil
 	}
 
 	result, err := pc.schema.Validate(gojsonschema.NewGoLoader(pluginSpec))
 	if err != nil {
-		return validationResult{}, errors.Wrap(err, "error validating plugin spec")
+		return ValidationResult{}, errors.Wrap(err, "error validating plugin spec")
 	}
 
 	if !result.Valid() {
@@ -52,8 +52,8 @@ func (pc *Container) ValidateSpec(pluginSpec map[string]interface{}) (validation
 			errs = append(errs, errors.New(validationErr.String()))
 		}
 
-		return validationResult{errs}, nil
+		return ValidationResult{errs}, nil
 	}
 
-	return validationResult{}, nil
+	return ValidationResult{}, nil
 }

--- a/pkg/store/catalog.go
+++ b/pkg/store/catalog.go
@@ -4,7 +4,6 @@ package store
 
 import (
 	"fmt"
-	"strings"
 	"sync"
 
 	sc_v1b1 "github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog/v1beta1"
@@ -30,6 +29,10 @@ const (
 type schemaWithResourceVersion struct {
 	resourceVersion string
 	schema          *gojsonschema.Schema
+}
+
+type validationResult struct {
+	Errors []error
 }
 
 // Catalog is a convenience interface to access OSB catalog information
@@ -251,14 +254,14 @@ func (c *Catalog) getParsedSchema(plan *sc_v1b1.ClusterServicePlan, action planS
 	return schema, nil
 }
 
-func (c *Catalog) ValidateServiceInstanceSpec(serviceInstanceSpec *sc_v1b1.ServiceInstanceSpec) error {
+func (c *Catalog) ValidateServiceInstanceSpec(serviceInstanceSpec *sc_v1b1.ServiceInstanceSpec) (validationResult, error) {
 	if len(serviceInstanceSpec.ParametersFrom) > 0 {
-		return errors.New("cannot validate ServiceInstanceSpec which has a ParametersFrom block (insufficient information)")
+		return validationResult{}, errors.New("cannot validate ServiceInstanceSpec which has a ParametersFrom block (insufficient information)")
 	}
 
 	servicePlan, err := c.GetPlanOf(serviceInstanceSpec)
 	if err != nil {
-		return err
+		return validationResult{}, err
 	}
 
 	// We ignore the update schema here and assume it's equivalent to
@@ -266,11 +269,13 @@ func (c *Catalog) ValidateServiceInstanceSpec(serviceInstanceSpec *sc_v1b1.Servi
 	// them anyway as there are currently no true PATCH updates).
 	schema, err := c.getParsedSchema(servicePlan, instanceCreateAction)
 	if err != nil {
-		return err
+		return validationResult{
+			Errors: []error{err},
+		}, nil
 	}
 	if schema == nil {
 		// no schema to validate against anyway
-		return nil
+		return validationResult{}, nil
 	}
 	var parameters []byte
 	if serviceInstanceSpec.Parameters != nil {
@@ -282,22 +287,21 @@ func (c *Catalog) ValidateServiceInstanceSpec(serviceInstanceSpec *sc_v1b1.Servi
 		// parameters will give sane looking early validation failures...
 		parameters = []byte("{}")
 	}
-	validationResult, err := schema.Validate(gojsonschema.NewBytesLoader(parameters))
+	result, err := schema.Validate(gojsonschema.NewBytesLoader(parameters))
 	if err != nil {
-		return errors.Wrapf(err, "error validating osb resource parameters for %q", servicePlan.Spec.ExternalName)
+		return validationResult{}, errors.Wrapf(err, "error validating osb resource parameters for %q", servicePlan.Spec.ExternalName)
 	}
 
-	if !validationResult.Valid() {
-		validationErrors := validationResult.Errors()
-		msgs := make([]string, 0, len(validationErrors))
+	if !result.Valid() {
+		validationErrors := result.Errors()
+		errs := make([]error, 0, len(validationErrors))
 
 		for _, validationErr := range validationErrors {
-			msgs = append(msgs, validationErr.String())
+			errs = append(errs, errors.New(validationErr.String()))
 		}
 
-		return errors.Errorf("spec failed validation against schema: %s",
-			strings.Join(msgs, ", "))
+		return validationResult{errs}, nil
 	}
 
-	return nil
+	return validationResult{}, nil
 }


### PR DESCRIPTION
This follows on from the other PR (https://github.com/atlassian/smith/pull/370).

The prevalidate step now returns resourceStatus which contains more information on if the validation failures were because of external things, or internal things (i.e. plugin failures)