### PR TITLE
Add an event recorder

### DIFF
--- a/api.go
+++ b/api.go
@@ -18,4 +18,5 @@ const (
 	EventReasonBundleInProgress   = "BundleInProgress"
 	EventReasonBundleReady        = "BundleReady"
 	EventReasonBundleError        = "BundleError"
+	EventReasonUnknown            = "Unknown"
 )

--- a/api.go
+++ b/api.go
@@ -1,6 +1,7 @@
 package smith
 
 const (
+	Smith  = "smith"
 	Domain = "smith.atlassian.com"
 
 	// See docs/design/managing-resources.md

--- a/api.go
+++ b/api.go
@@ -8,4 +8,14 @@ const (
 	CrFieldPathAnnotation  = Domain + "/CrReadyWhenFieldPath"
 	CrFieldValueAnnotation = Domain + "/CrReadyWhenFieldValue"
 	CrdSupportEnabled      = Domain + "/SupportEnabled"
+
+	EventAnnotationResourceName = Domain + "/ResourceName"
+	EventAnnotationReason       = Domain + "/Reason"
+
+	EventReasonResourceInProgress = "ResourceInProgress"
+	EventReasonResourceReady      = "ResourceReady"
+	EventReasonResourceError      = "ResourceError"
+	EventReasonBundleInProgress   = "BundleInProgress"
+	EventReasonBundleReady        = "BundleReady"
+	EventReasonBundleError        = "BundleError"
 )

--- a/cmd/smith/app/BUILD.bazel
+++ b/cmd/smith/app/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
     importpath = "github.com/atlassian/smith/cmd/smith/app",
     visibility = ["//visibility:public"],
     deps = [
+        "//:go_default_library",
         "//pkg/apis/smith/v1:go_default_library",
         "//pkg/client:go_default_library",
         "//pkg/client/clientset_generated/clientset:go_default_library",
@@ -40,5 +41,6 @@ go_library(
         "//vendor/k8s.io/client-go/kubernetes:go_default_library",
         "//vendor/k8s.io/client-go/restmapper:go_default_library",
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",
+        "//vendor/k8s.io/client-go/tools/record:go_default_library",
     ],
 )

--- a/pkg/controller/bundlec/BUILD.bazel
+++ b/pkg/controller/bundlec/BUILD.bazel
@@ -47,7 +47,10 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/util/json:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/watch:go_default_library",
         "//vendor/k8s.io/client-go/dynamic:go_default_library",
+        "//vendor/k8s.io/client-go/kubernetes:go_default_library",
+        "//vendor/k8s.io/client-go/kubernetes/typed/core/v1:go_default_library",
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",
+        "//vendor/k8s.io/client-go/tools/record:go_default_library",
     ],
 )
 

--- a/pkg/controller/bundlec/bundle_sync_task.go
+++ b/pkg/controller/bundlec/bundle_sync_task.go
@@ -629,6 +629,10 @@ func (st *bundleSyncTask) checkBundleConditionNeedsUpdate(condition *cond_v1.Con
 		case smith_v1.BundleReady:
 			eventType = core_v1.EventTypeNormal
 			reason = smith.EventReasonBundleReady
+		default:
+			st.logger.Sugar().Errorf("Unexpected bundle condition type %q", condition.Type)
+			eventType = core_v1.EventTypeWarning
+			reason = smith.EventReasonUnknown
 		}
 		st.recorder.AnnotatedEventf(st.bundle, eventAnnotations, eventType, reason, condition.Message)
 	}
@@ -678,6 +682,10 @@ func (st *bundleSyncTask) checkResourceConditionNeedsUpdate(resName smith_v1.Res
 			case smith_v1.ResourceReady:
 				eventType = core_v1.EventTypeNormal
 				reason = smith.EventReasonResourceReady
+			default:
+				st.logger.Sugar().Errorf("Unexpected resource condition type %q", condition.Type)
+				eventType = core_v1.EventTypeWarning
+				reason = smith.EventReasonUnknown
 			}
 			st.recorder.AnnotatedEventf(st.bundle, eventAnnotations, eventType, reason, condition.Message)
 		}

--- a/pkg/controller/bundlec/bundle_sync_task.go
+++ b/pkg/controller/bundlec/bundle_sync_task.go
@@ -628,12 +628,10 @@ func (st *bundleSyncTask) checkBundleConditionNeedsUpdate(condition *cond_v1.Con
 			EventAnnotationReason: condition.Reason,
 		}
 		eventType := core_v1.EventTypeNormal
-		reason := EventReasonBundlePrefix + string(condition.Type)
 		if condition.Type == smith_v1.BundleError {
 			eventType = core_v1.EventTypeWarning
-			reason = EventReasonBundlePrefix + condition.Reason
 		}
-		st.recorder.AnnotatedEventf(st.bundle, eventAnnotations, eventType, reason, condition.Message)
+		st.recorder.AnnotatedEventf(st.bundle, eventAnnotations, eventType, EventReasonResourcePrefix+string(condition.Type), condition.Message)
 	}
 
 	// Return true if one of the fields have changed.

--- a/pkg/controller/bundlec/bundle_sync_task.go
+++ b/pkg/controller/bundlec/bundle_sync_task.go
@@ -631,7 +631,7 @@ func (st *bundleSyncTask) checkBundleConditionNeedsUpdate(condition *cond_v1.Con
 		if condition.Type == smith_v1.BundleError {
 			eventType = core_v1.EventTypeWarning
 		}
-		st.recorder.AnnotatedEventf(st.bundle, eventAnnotations, eventType, EventReasonResourcePrefix+string(condition.Type), condition.Message)
+		st.recorder.AnnotatedEventf(st.bundle, eventAnnotations, eventType, EventReasonBundlePrefix+string(condition.Type), condition.Message)
 	}
 
 	// Return true if one of the fields have changed.

--- a/pkg/controller/bundlec/controller.go
+++ b/pkg/controller/bundlec/controller.go
@@ -15,6 +15,7 @@ import (
 	"github.com/atlassian/smith/pkg/store"
 	"github.com/prometheus/client_golang/prometheus"
 	"go.uber.org/zap"
+	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/kubernetes"
@@ -99,7 +100,7 @@ func (c *Controller) Run(ctx context.Context) {
 	defer c.Logger.Info("Shutting down Bundle controller")
 
 	sink := core_v1_client.EventSinkImpl{
-		Interface: c.MainClient.CoreV1().Events(""),
+		Interface: c.MainClient.CoreV1().Events(meta_v1.NamespaceNone),
 	}
 	recordingWatch := c.Broadcaster.StartRecordingToSink(&sink)
 	defer recordingWatch.Stop()

--- a/pkg/controller/bundlec/controller_worker.go
+++ b/pkg/controller/bundlec/controller_worker.go
@@ -29,6 +29,7 @@ func (c *Controller) ProcessBundle(logger *zap.Logger, bundle *smith_v1.Bundle) 
 		catalog:                         c.Catalog,
 		bundleTransitionCounter:         c.BundleTransitionCounter,
 		bundleResourceTransitionCounter: c.BundleResourceTransitionCounter,
+		recorder:                        c.Recorder,
 	}
 
 	var retriable bool


### PR DESCRIPTION
Fixes #94.
```
21s         Normal   ResourceInProgress            Bundle            UpdateInstanceRequestInFlight: Update request for ServiceInstance in-flight to Broker
21s         Normal   BundleInProgress              Bundle
20s         Normal   ResourceInProgress            Bundle            UpdatingInstance: The instance is being updated asynchronously
19s         Normal   ResourceInProgress            Bundle            UpdatingInstance: The instance is being updated asynchronously (Resource is being updated)
5s          Normal   ResourceReady                 Bundle            InstanceUpdatedSuccessfully: The instance was updated successfully
5s          Normal   ResourceReady                 Bundle            InjectedBindResult: Injected bind result
5s          Normal   ResourceReady                 Bundle
5s          Normal   ResourceReady                 Bundle            ProvisionedSuccessfully: The instance was provisioned successfully
5s          Normal   BundleReady                   Bundle
```

Each event is annotated with the resource name:

```
apiVersion: v1
count: 1
eventTime: null
firstTimestamp: 2018-11-20T07:14:33Z
involvedObject:
  apiVersion: smith.atlassian.com/v1
  kind: Bundle
  name: ychen-test-svc
  namespace: ychen-test-svc
  resourceVersion: "264528178"
  uid: a6ee32d4-e639-11e8-8e98-0a3eedf23e70
kind: Event
lastTimestamp: 2018-11-20T07:14:33Z
message: 'Blocked True "DependenciesNotReady" "Not ready: [\"noderefapp--basic--binding\"]"'
metadata:
  annotations:
    smith.atlassian.com/ResourceName: noderefapp--secretenvvar
  creationTimestamp: 2018-11-20T07:14:33Z
  name: ychen-test-svc.1568c3b96ba65b73
  namespace: ychen-test-svc
  resourceVersion: "64657438"
  selfLink: /api/v1/namespaces/ychen-test-svc/events/ychen-test-svc.1568c3b96ba65b73
  uid: ee30b1b0-ec93-11e8-8be6-06167b28a4ca
reason: ResourceBlocked
reportingComponent: ""
reportingInstance: ""
source:
  component: smith
type: Normal
```

Why is this good? Because we can see stuff like this in the events now:

```
4s          Normal   ResourceInProgress            Bundle            UpdatingInstance: The instance is being updated asynchronously (See Micros events using 'micros stream:poll ychen-test-svc-noderefapp -e ddev -i qhlpdjse1orn3e4p')
```

Using another system that groups these events and resources together we can build a nicer summary of what exactly happened in the state.