### PR TITLE
multirun does not work with rules_docker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -163,4 +163,7 @@ docker-export:
 release: update-bazel
 	bazel run \
 		--platforms=@io_bazel_rules_go//go/toolchain:linux_amd64 \
-		//cmd/smith:push_docker_all
+		//cmd/smith:push_docker
+	bazel run \
+		--platforms=@io_bazel_rules_go//go/toolchain:linux_amd64 \
+		//cmd/smith:push_docker_race

--- a/cmd/smith/BUILD.bazel
+++ b/cmd/smith/BUILD.bazel
@@ -1,7 +1,6 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 load("@io_bazel_rules_docker//container:container.bzl", "container_push")
 load("@io_bazel_rules_docker//go:image.bzl", "go_image")
-load("@com_github_atlassian_bazel_tools//:multirun/def.bzl", "multirun")
 
 go_library(
     name = "go_default_library",
@@ -62,12 +61,4 @@ container_push(
     stamp = True,
     tag = "{STABLE_BUILD_GIT_TAG}-{STABLE_BUILD_GIT_COMMIT}-race",
     tags = ["manual"],
-)
-
-multirun(
-    name = "push_docker_all",
-    commands = [
-        ":push_docker",
-        ":push_docker_race",
-    ],
 )


### PR DESCRIPTION
As we have discovered today, multirun does not work properly with cross-compilation for a complicated reason.