### PR TITLE
Support disabling of last applied replicas

### DIFF
--- a/pkg/specchecker/builtin/process_deployment.go
+++ b/pkg/specchecker/builtin/process_deployment.go
@@ -74,6 +74,10 @@ func (d deployment) ApplySpec(ctx *specchecker.Context, spec, actual *unstructur
 // to avoid conflicts with other controllers like HPA.
 // actual may be nil.
 func (deployment) setLastAppliedReplicasAnnotation(ctx *specchecker.Context, spec, actual *apps_v1.Deployment) {
+	if spec.Annotations[LastAppliedReplicasAnnotation] == Disabled {
+		return
+	}
+
 	if spec.Spec.Replicas == nil {
 		var one int32 = 1
 		spec.Spec.Replicas = &one

--- a/pkg/specchecker/builtin/process_deployment_test.go
+++ b/pkg/specchecker/builtin/process_deployment_test.go
@@ -756,8 +756,7 @@ func TestDeploymentAnnotationExplicitlyDisabled(t *testing.T) {
 	deploymentCheck := updatedSpec.(*apps_v1.Deployment)
 
 	assert.Contains(t, deploymentCheck.Spec.Template.Annotations, EnvRefHashAnnotation)
-	assert.Contains(t, deploymentCheck.Spec.Template.Annotations, EnvRefHashAnnotation)
-	assert.Equal(t, deploymentCheck.Spec.Template.Annotations[EnvRefHashAnnotation], "disabled")
+	assert.Equal(t, "disabled", deploymentCheck.Spec.Template.Annotations[EnvRefHashAnnotation])
 }
 
 func TestUserEnteredAnnotationOverridden(t *testing.T) {

--- a/pkg/specchecker/builtin/process_deployment_test.go
+++ b/pkg/specchecker/builtin/process_deployment_test.go
@@ -975,6 +975,47 @@ func TestDeploymentUpdatedSecrets(t *testing.T) {
 	assert.NotEqual(t, secondDeploymentCheck.Spec.Template.Annotations[EnvRefHashAnnotation], firstHash)
 }
 
+func TestLastAppliedReplicasExplicitlyDisabled(t *testing.T) {
+	t.Parallel()
+
+	deploymentSpec := apps_v1.Deployment{
+		TypeMeta: meta_v1.TypeMeta{
+			Kind:       "Deployment",
+			APIVersion: apps_v1.SchemeGroupVersion.String(),
+		},
+		ObjectMeta: meta_v1.ObjectMeta{
+			Namespace: testNs,
+			Annotations: map[string]string{
+				LastAppliedReplicasAnnotation: "disabled",
+			},
+		},
+		Spec: apps_v1.DeploymentSpec{
+			Template: core_v1.PodTemplateSpec{
+				Spec: core_v1.PodSpec{
+					Containers: []core_v1.Container{
+						core_v1.Container{
+							Image: "some/image:tag",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	spec := runtimeToUnstructured(t, &deploymentSpec)
+
+	logger := zaptest.NewLogger(t)
+	defer logger.Sync() // nolint: errcheck
+	store := speccheckertesting.FakeStore{Namespace: testNs}
+
+	updatedSpec, err := deployment{}.BeforeCreate(&specchecker.Context{Logger: logger, Store: store}, spec)
+	require.NoError(t, err)
+
+	deploymentCheck := updatedSpec.(*apps_v1.Deployment)
+	assert.Contains(t, deploymentCheck.Annotations, LastAppliedReplicasAnnotation)
+	assert.Equal(t, "disabled", deploymentCheck.Annotations[LastAppliedReplicasAnnotation])
+}
+
 func runtimeToUnstructured(t *testing.T, obj runtime.Object) *unstructured.Unstructured {
 	out, err := util.RuntimeToUnstructured(obj)
 	require.NoError(t, err)

--- a/pkg/specchecker/checker_test.go
+++ b/pkg/specchecker/checker_test.go
@@ -352,6 +352,11 @@ func TestEqualityUnequal(t *testing.T) {
 				Spec: apps_v1.DeploymentSpec{
 					Replicas: &newNumberOfReplicas,
 					Template: core_v1.PodTemplateSpec{
+						ObjectMeta: meta_v1.ObjectMeta{
+							Annotations: map[string]string{
+								builtin.EnvRefHashAnnotation: "disabled",
+							},
+						},
 						Spec: core_v1.PodSpec{
 							Containers: []core_v1.Container{
 								{
@@ -382,6 +387,11 @@ func TestEqualityUnequal(t *testing.T) {
 				Spec: apps_v1.DeploymentSpec{
 					Replicas: &numberOfReplicas,
 					Template: core_v1.PodTemplateSpec{
+						ObjectMeta: meta_v1.ObjectMeta{
+							Annotations: map[string]string{
+								builtin.EnvRefHashAnnotation: "disabled",
+							},
+						},
 						Spec: core_v1.PodSpec{
 							Containers: []core_v1.Container{
 								{
@@ -404,6 +414,68 @@ func TestEqualityUnequal(t *testing.T) {
 			},
 		},
 		{
+			name: "Deployment with lastAppliedReplicas newly disabled",
+			spec: &apps_v1.Deployment{
+				TypeMeta: meta_v1.TypeMeta{
+					Kind:       "Deployment",
+					APIVersion: apps_v1.SchemeGroupVersion.String(),
+				},
+				ObjectMeta: meta_v1.ObjectMeta{
+					Annotations: map[string]string{
+						builtin.LastAppliedReplicasAnnotation: "disabled",
+					},
+				},
+				Spec: apps_v1.DeploymentSpec{
+					// number of replicas is the same, but annotation is different
+					Replicas: &numberOfReplicas,
+					Template: core_v1.PodTemplateSpec{
+						ObjectMeta: meta_v1.ObjectMeta{
+							Annotations: map[string]string{
+								builtin.EnvRefHashAnnotation: "disabled",
+							},
+						},
+						Spec: core_v1.PodSpec{
+							Containers: []core_v1.Container{
+								{
+									Name:  "c1",
+									Image: "ima.ge",
+								},
+							},
+						},
+					},
+				},
+			},
+			actual: &apps_v1.Deployment{
+				TypeMeta: meta_v1.TypeMeta{
+					Kind:       "Deployment",
+					APIVersion: apps_v1.SchemeGroupVersion.String(),
+				},
+				ObjectMeta: meta_v1.ObjectMeta{
+					Annotations: map[string]string{
+						builtin.LastAppliedReplicasAnnotation: strconv.Itoa(int(numberOfReplicas)),
+					},
+				},
+				Spec: apps_v1.DeploymentSpec{
+					Replicas: &numberOfReplicas,
+					Template: core_v1.PodTemplateSpec{
+						ObjectMeta: meta_v1.ObjectMeta{
+							Annotations: map[string]string{
+								builtin.EnvRefHashAnnotation: "disabled",
+							},
+						},
+						Spec: core_v1.PodSpec{
+							Containers: []core_v1.Container{
+								{
+									Name:  "c1",
+									Image: "ima.ge",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
 			name: "Deployment with wrong format running replicas annotation",
 			spec: &apps_v1.Deployment{
 				TypeMeta: meta_v1.TypeMeta{
@@ -416,6 +488,11 @@ func TestEqualityUnequal(t *testing.T) {
 				Spec: apps_v1.DeploymentSpec{
 					Replicas: &numberOfReplicas,
 					Template: core_v1.PodTemplateSpec{
+						ObjectMeta: meta_v1.ObjectMeta{
+							Annotations: map[string]string{
+								builtin.EnvRefHashAnnotation: "disabled",
+							},
+						},
 						Spec: core_v1.PodSpec{
 							Containers: []core_v1.Container{
 								{
@@ -446,6 +523,11 @@ func TestEqualityUnequal(t *testing.T) {
 				Spec: apps_v1.DeploymentSpec{
 					Replicas: &numberOfReplicas,
 					Template: core_v1.PodTemplateSpec{
+						ObjectMeta: meta_v1.ObjectMeta{
+							Annotations: map[string]string{
+								builtin.EnvRefHashAnnotation: "disabled",
+							},
+						},
 						Spec: core_v1.PodSpec{
 							Containers: []core_v1.Container{
 								{


### PR DESCRIPTION
Add the ability to disable the "lastAppliedReplicas" functionality, for cases where you do want Smith to manage the replicas field.

Fixes #385.