### PR TITLE
Changed smith to propogate external errors up to ctrl layer

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -14,7 +14,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:3b68cf4e03d5b40a7d4aa40f3ce9c48d34ef4bcef9e255fc7fe37df0be1c9bb4"
+  digest = "1:a91d278d1ba3f4d51548531a3601548ee25f30a963b7de67607fdac9af0d9f3a"
   name = "github.com/atlassian/ctrl"
   packages = [
     ".",
@@ -27,7 +27,7 @@
     "process",
   ]
   pruneopts = "NT"
-  revision = "30152a801242bb7aa023702c184d4aa919dab4bc"
+  revision = "1cea8338282d871a8fd8c2cebd24ad177b25240e"
 
 [[projects]]
   digest = "1:07918ac16957399fa68bf94b3ab26dccccc6992f1ccbcf589896734569a0a7e7"

--- a/pkg/controller/bundlec/controller_worker.go
+++ b/pkg/controller/bundlec/controller_worker.go
@@ -63,7 +63,7 @@ func (c *Controller) ProcessBundle(logger *zap.Logger, bundle *smith_v1.Bundle) 
 	// over the handleProcessErr if any.
 	if err != nil {
 		if handleProcessErr != nil {
-			st.logger.Error("Error updating Bundle", zap.Error(handleProcessErr))
+			st.logger.Error("Error processing Bundle", zap.Error(handleProcessErr))
 		}
 
 		return external, retriable || handleProcessRetriable, err
@@ -72,7 +72,7 @@ func (c *Controller) ProcessBundle(logger *zap.Logger, bundle *smith_v1.Bundle) 
 	// Inspect resources, returning an error if necessary
 	allExternalErrors := true
 	hasRetriableResourceErr := false
-	failedResources := make([]string, 0, len(st.processedResources))
+	var failedResources []string
 	for resName, resInfo := range st.processedResources {
 		resErr := resInfo.fetchError()
 
@@ -84,10 +84,10 @@ func (c *Controller) ProcessBundle(logger *zap.Logger, bundle *smith_v1.Bundle) 
 	}
 	if len(failedResources) > 0 {
 		if handleProcessErr != nil {
-			st.logger.Error("Error updating Bundle", zap.Error(handleProcessErr))
+			st.logger.Error("Error processing Bundle", zap.Error(handleProcessErr))
 		}
 		// stable output
-		sort.Sort(failedResources)
+		sort.Strings(failedResources)
 		err := errors.Errorf("error processing resource(s): %q", failedResources)
 		return allExternalErrors, hasRetriableResourceErr || handleProcessRetriable, err
 	}

--- a/pkg/controller/bundlec/controller_worker.go
+++ b/pkg/controller/bundlec/controller_worker.go
@@ -1,6 +1,8 @@
 package bundlec
 
 import (
+	"sort"
+
 	"github.com/atlassian/ctrl"
 	smith_v1 "github.com/atlassian/smith/pkg/apis/smith/v1"
 	"github.com/pkg/errors"
@@ -84,6 +86,8 @@ func (c *Controller) ProcessBundle(logger *zap.Logger, bundle *smith_v1.Bundle) 
 		if handleProcessErr != nil {
 			st.logger.Error("Error updating Bundle", zap.Error(handleProcessErr))
 		}
+		// stable output
+		sort.Sort(failedResources)
 		err := errors.Errorf("error processing resource(s): %q", failedResources)
 		return allExternalErrors, hasRetriableResourceErr || handleProcessRetriable, err
 	}

--- a/pkg/controller/bundlec/controller_worker.go
+++ b/pkg/controller/bundlec/controller_worker.go
@@ -1,8 +1,6 @@
 package bundlec
 
 import (
-	"context"
-
 	"github.com/atlassian/ctrl"
 	smith_v1 "github.com/atlassian/smith/pkg/apis/smith/v1"
 	"github.com/pkg/errors"
@@ -10,12 +8,12 @@ import (
 	api_errors "k8s.io/apimachinery/pkg/api/errors"
 )
 
-func (c *Controller) Process(pctx *ctrl.ProcessContext) (bool /*retriable*/, error) {
+func (c *Controller) Process(pctx *ctrl.ProcessContext) (bool /*external*/, bool /*retriable*/, error) {
 	return c.ProcessBundle(pctx.Logger, pctx.Object.(*smith_v1.Bundle))
 }
 
 // ProcessBundle is only visible for testing purposes. Should not be called directly.
-func (c *Controller) ProcessBundle(logger *zap.Logger, bundle *smith_v1.Bundle) (bool /*retriable*/, error) {
+func (c *Controller) ProcessBundle(logger *zap.Logger, bundle *smith_v1.Bundle) (bool /*external*/, bool /*retriable*/, error) {
 	st := bundleSyncTask{
 		logger:                          logger,
 		bundleClient:                    c.BundleClient,
@@ -32,19 +30,64 @@ func (c *Controller) ProcessBundle(logger *zap.Logger, bundle *smith_v1.Bundle) 
 		recorder:                        c.Recorder,
 	}
 
+	var external bool
 	var retriable bool
 	var err error
 	if st.bundle.DeletionTimestamp != nil {
-		retriable, err = st.processDeleted()
+		external, retriable, err = st.processDeleted()
 	} else {
-		retriable, err = st.processNormal()
+		external, retriable, err = st.processNormal()
 	}
 	if err != nil {
 		cause := errors.Cause(err)
-		if api_errors.IsConflict(cause) || cause == context.Canceled || cause == context.DeadlineExceeded {
-			return retriable, err
+		// short circuit on conflicts
+		if api_errors.IsConflict(cause) {
+			return external, retriable, err
 		}
 		// proceed to handleProcessResult() for all other errors
 	}
-	return st.handleProcessResult(retriable, err)
+
+	// Updates bundle status
+	handleProcessRetriable, handleProcessErr := st.handleProcessResult(retriable, err)
+
+	// Inspect the resources for failures. They can fail for many different reasons.
+	// The priority of errors to bubble up to the ctrl layer are:
+	//  1. processDeleted/processNormal errors
+	//  2. Internal resource processing errors are raised first
+	//  3. External resource processing errors are raised last
+	//  4. handleProcessResult errors of any sort.
+
+	// Handle the errors from processDeleted/processNormal, taking precedence
+	// over the handleProcessErr if any.
+	if err != nil {
+		if handleProcessErr != nil {
+			st.logger.Error("Error updating Bundle", zap.Error(handleProcessErr))
+		}
+
+		return external, retriable || handleProcessRetriable, err
+	}
+
+	// Inspect resources, returning an error if necessary
+	allExternalErrors := true
+	hasRetriableResourceErr := false
+	failedResources := make([]string, 0, len(st.processedResources))
+	for resName, resInfo := range st.processedResources {
+		resErr := resInfo.fetchError()
+
+		if resErr != nil {
+			allExternalErrors = allExternalErrors && resErr.isExternalError
+			hasRetriableResourceErr = hasRetriableResourceErr || resErr.isRetriableError
+			failedResources = append(failedResources, string(resName))
+		}
+	}
+	if len(failedResources) > 0 {
+		if handleProcessErr != nil {
+			st.logger.Error("Error updating Bundle", zap.Error(handleProcessErr))
+		}
+		err := errors.Errorf("error processing resource(s): %q", failedResources)
+		return allExternalErrors, hasRetriableResourceErr || handleProcessRetriable, err
+	}
+
+	// Otherwise, return the result from handleProcessResult
+	return false, handleProcessRetriable, handleProcessErr
 }

--- a/pkg/controller/bundlec/resource_sync_task.go
+++ b/pkg/controller/bundlec/resource_sync_task.go
@@ -640,6 +640,7 @@ func (st *resourceSyncTask) validateSpec(spec *unstructured.Unstructured) resour
 				return resourceStatusError{
 					err:              errors.Errorf("annotation %q cannot be set by the user", key),
 					isRetriableError: false,
+					isExternalError:  true,
 				}
 			}
 		}

--- a/pkg/controller/bundlec_test/cleanup_test.go
+++ b/pkg/controller/bundlec_test/cleanup_test.go
@@ -75,8 +75,9 @@ func TestCleanupOfInvalidPlugin(t *testing.T) {
 		pluginsShouldBeInvoked: sets.NewString(),
 		test: func(t *testing.T, ctx context.Context, cntrlr *bundlec.Controller, tc *testCase) {
 			require.NotNil(t, tc.bundle)
-			_, err := cntrlr.ProcessBundle(tc.logger, tc.bundle)
+			external, _, err := cntrlr.ProcessBundle(tc.logger, tc.bundle)
 			require.Error(t, err)
+			assert.True(t, external, "error should be an external error")
 			assert.EqualError(t, err, "plugin \"configMapWithDeps\" is not a valid plugin")
 		},
 	}
@@ -115,8 +116,9 @@ func TestCleanupOfNeitherPluginOrObject(t *testing.T) {
 		pluginsShouldBeInvoked: sets.NewString(),
 		test: func(t *testing.T, ctx context.Context, cntrlr *bundlec.Controller, tc *testCase) {
 			require.NotNil(t, tc.bundle)
-			_, err := cntrlr.ProcessBundle(tc.logger, tc.bundle)
+			external, _, err := cntrlr.ProcessBundle(tc.logger, tc.bundle)
 			require.Error(t, err)
+			assert.True(t, external, "error should be an external error")
 			assert.EqualError(t, err, "resource is neither object nor plugin")
 		},
 	}

--- a/pkg/controller/bundlec_test/deleted_bundle_manual_delete_resources_fail_test.go
+++ b/pkg/controller/bundlec_test/deleted_bundle_manual_delete_resources_fail_test.go
@@ -81,7 +81,8 @@ func TestKeepFinalizerWhenResourceDeletionFails(t *testing.T) {
 		namespace:            testNamespace,
 		enableServiceCatalog: false,
 		test: func(t *testing.T, ctx context.Context, cntrlr *bundlec.Controller, tc *testCase) {
-			_, err := cntrlr.ProcessBundle(tc.logger, tc.bundle)
+			external, _, err := cntrlr.ProcessBundle(tc.logger, tc.bundle)
+			assert.False(t, external, "error should be an internal error")
 			assert.EqualError(t, err, `an error on the server ("unknown") has prevented the request from succeeding`)
 
 			actions := tc.smithFake.Actions()

--- a/pkg/controller/bundlec_test/detect_infinite_update_cycles_test.go
+++ b/pkg/controller/bundlec_test/detect_infinite_update_cycles_test.go
@@ -62,9 +62,11 @@ func TestDetectInfiniteUpdateCycles(t *testing.T) {
 			},
 		},
 		test: func(t *testing.T, ctx context.Context, cntrlr *bundlec.Controller, tc *testCase) {
-			retriable, err := cntrlr.ProcessBundle(tc.logger, tc.bundle)
+			external, retriable, err := cntrlr.ProcessBundle(tc.logger, tc.bundle)
 			assert.EqualError(t, err, `error processing resource(s): ["`+mapNeedsAnUpdate+`"]`)
-			assert.False(t, retriable)
+			assert.False(t, external, "error should be an internal error")
+			assert.False(t, retriable, "error should not be retriable")
+
 			actions := tc.smithFake.Actions()
 			require.Len(t, actions, 3)
 			bundleUpdate := actions[2].(kube_testing.UpdateAction)

--- a/pkg/controller/bundlec_test/invalid_depends_on_test.go
+++ b/pkg/controller/bundlec_test/invalid_depends_on_test.go
@@ -48,9 +48,10 @@ func TestInvalidReferences(t *testing.T) {
 			pluginConfigMapWithDeps: configMapWithDependenciesPlugin(false, false),
 		},
 		test: func(t *testing.T, ctx context.Context, cntrlr *bundlec.Controller, tc *testCase) {
-			retriable, err := cntrlr.ProcessBundle(tc.logger, tc.bundle)
+			external, retriable, err := cntrlr.ProcessBundle(tc.logger, tc.bundle)
 			assert.EqualError(t, err, `topological sort of resources failed: vertex "bla" not found`)
-			assert.False(t, retriable)
+			assert.True(t, external, "error should be an external error")
+			assert.False(t, retriable, "error should not be retriable")
 
 			actions := tc.smithFake.Actions()
 			require.Len(t, actions, 3)

--- a/pkg/controller/bundlec_test/no_actions_for_blocked_resources_test.go
+++ b/pkg/controller/bundlec_test/no_actions_for_blocked_resources_test.go
@@ -99,9 +99,10 @@ func TestNoActionsForBlockedResources(t *testing.T) {
 		namespace:            testNamespace,
 		enableServiceCatalog: true,
 		test: func(t *testing.T, ctx context.Context, cntrlr *bundlec.Controller, tc *testCase) {
-			retriable, err := cntrlr.ProcessBundle(tc.logger, tc.bundle)
+			external, retriable, err := cntrlr.ProcessBundle(tc.logger, tc.bundle)
 			assert.EqualError(t, err, `error processing resource(s): ["`+resSi1+`"]`)
-			assert.False(t, retriable)
+			assert.True(t, external, "error should be an external error") // service instance failure
+			assert.False(t, retriable, "error should not be retriable")
 			actions := tc.smithFake.Actions()
 			require.Len(t, actions, 3)
 			bundleUpdate := actions[2].(kube_testing.UpdateAction)

--- a/pkg/controller/bundlec_test/plugin_error_propagated_test.go
+++ b/pkg/controller/bundlec_test/plugin_error_propagated_test.go
@@ -45,9 +45,10 @@ func TestPluginErrorPropagated(t *testing.T) {
 		},
 		pluginsShouldBeInvoked: sets.NewString(string(pluginFailing)),
 		test: func(t *testing.T, ctx context.Context, cntrlr *bundlec.Controller, tc *testCase) {
-			retriable, err := cntrlr.ProcessBundle(tc.logger, tc.bundle)
+			external, retriable, err := cntrlr.ProcessBundle(tc.logger, tc.bundle)
 			assert.EqualError(t, err, `error processing resource(s): ["`+resP1+`"]`)
-			assert.False(t, retriable)
+			assert.False(t, external, "error should be an internal error") // 'failingPlugin' returns internal err
+			assert.False(t, retriable, "error should not be a retriable error")
 
 			actions := tc.smithFake.Actions()
 			require.Len(t, actions, 3)

--- a/pkg/controller/bundlec_test/plugin_schema_invalid_test.go
+++ b/pkg/controller/bundlec_test/plugin_schema_invalid_test.go
@@ -46,9 +46,10 @@ func TestPluginSchemaInvalid(t *testing.T) {
 			pluginConfigMapWithDeps: configMapWithDependenciesPlugin(false, false),
 		},
 		test: func(t *testing.T, ctx context.Context, cntrlr *bundlec.Controller, tc *testCase) {
-			retriable, err := cntrlr.ProcessBundle(tc.logger, tc.bundle)
+			external, retriable, err := cntrlr.ProcessBundle(tc.logger, tc.bundle)
 			assert.EqualError(t, err, `error processing resource(s): ["`+resP1+`"]`)
-			assert.False(t, retriable)
+			assert.True(t, external, "error should be an external error")
+			assert.False(t, retriable, "error should not be retriable error")
 
 			actions := tc.smithFake.Actions()
 			require.Len(t, actions, 3)

--- a/pkg/controller/bundlec_test/processing_continues_after_error_test.go
+++ b/pkg/controller/bundlec_test/processing_continues_after_error_test.go
@@ -83,9 +83,11 @@ func TestProcessingContinuesAfterNonBlockingError(t *testing.T) {
 			},
 		},
 		test: func(t *testing.T, ctx context.Context, cntrlr *bundlec.Controller, tc *testCase) {
-			retriable, err := cntrlr.ProcessBundle(tc.logger, tc.bundle)
+			external, retriable, err := cntrlr.ProcessBundle(tc.logger, tc.bundle)
 			assert.EqualError(t, err, `error processing resource(s): ["`+resSi1+`"]`)
-			assert.False(t, retriable)
+			assert.True(t, external, "error should be an external error") // service instance failure
+			assert.False(t, retriable, "error should not be a retriable error")
+
 			actions := tc.smithFake.Actions()
 			require.Len(t, actions, 3)
 			bundleUpdate := actions[2].(kube_testing.UpdateAction)

--- a/pkg/controller/bundlec_test/prohibited_annotations_object_test.go
+++ b/pkg/controller/bundlec_test/prohibited_annotations_object_test.go
@@ -59,9 +59,10 @@ func TestProhibitedAnnotationsObjectRejected(t *testing.T) {
 		appName:   testAppName,
 		namespace: testNamespace,
 		test: func(t *testing.T, ctx context.Context, cntrlr *bundlec.Controller, tc *testCase) {
-			retriable, err := cntrlr.ProcessBundle(tc.logger, tc.bundle)
+			external, retriable, err := cntrlr.ProcessBundle(tc.logger, tc.bundle)
 			assert.EqualError(t, err, `error processing resource(s): ["`+string(r1)+`"]`)
-			assert.False(t, retriable)
+			assert.True(t, external, "error should be an external error") // user tried to set annotation
+			assert.False(t, retriable, "error should not be a retriable error")
 
 			actions := tc.smithFake.Actions()
 			require.Len(t, actions, 3)

--- a/pkg/controller/bundlec_test/prohibited_annotations_plugin_test.go
+++ b/pkg/controller/bundlec_test/prohibited_annotations_plugin_test.go
@@ -67,9 +67,10 @@ func TestProhibitedAnnotationsPluginRejected(t *testing.T) {
 		},
 		pluginsShouldBeInvoked: sets.NewString(string(pluginMockConfigMap)),
 		test: func(t *testing.T, ctx context.Context, cntrlr *bundlec.Controller, tc *testCase) {
-			retriable, err := cntrlr.ProcessBundle(tc.logger, tc.bundle)
+			external, retriable, err := cntrlr.ProcessBundle(tc.logger, tc.bundle)
 			assert.EqualError(t, err, `error processing resource(s): ["`+string(r1)+`"]`)
-			assert.False(t, retriable)
+			assert.True(t, external, "error should be an external error") // annotation should not be set
+			assert.False(t, retriable, "error should not be a retriable error")
 
 			actions := tc.smithFake.Actions()
 			require.Len(t, actions, 3)

--- a/pkg/controller/bundlec_test/schema_early_validation_test.go
+++ b/pkg/controller/bundlec_test/schema_early_validation_test.go
@@ -187,9 +187,10 @@ func TestSchemaEarlyValidation(t *testing.T) {
 			pluginConfigMapWithDeps: configMapWithDependenciesPlugin(false, false),
 		},
 		test: func(t *testing.T, ctx context.Context, cntrlr *bundlec.Controller, tc *testCase) {
-			retriable, err := cntrlr.ProcessBundle(tc.logger, tc.bundle)
-			assert.False(t, retriable)
+			external, retriable, err := cntrlr.ProcessBundle(tc.logger, tc.bundle)
 			assert.EqualError(t, err, `error processing resource(s): ["`+resSiWithDefaults+`" "`+resPWithDefaults+`"]`)
+			assert.True(t, external, "error should be an external error") // bunch of spec validation errors
+			assert.False(t, retriable, "error should not be a retriable error")
 
 			actions := tc.smithFake.Actions()
 			require.Len(t, actions, 3)

--- a/pkg/controller/bundlec_test/schema_early_validation_test.go
+++ b/pkg/controller/bundlec_test/schema_early_validation_test.go
@@ -188,7 +188,7 @@ func TestSchemaEarlyValidation(t *testing.T) {
 		},
 		test: func(t *testing.T, ctx context.Context, cntrlr *bundlec.Controller, tc *testCase) {
 			external, retriable, err := cntrlr.ProcessBundle(tc.logger, tc.bundle)
-			assert.EqualError(t, err, `error processing resource(s): ["`+resSiWithDefaults+`" "`+resPWithDefaults+`"]`)
+			assert.EqualError(t, err, `error processing resource(s): ["`+resPWithDefaults+`" "`+resSiWithDefaults+`"]`)
 			assert.True(t, external, "error should be an external error") // bunch of spec validation errors
 			assert.False(t, retriable, "error should not be a retriable error")
 

--- a/pkg/controller/bundlec_test/service_instance_schema_invalid_test.go
+++ b/pkg/controller/bundlec_test/service_instance_schema_invalid_test.go
@@ -82,9 +82,10 @@ func TestServiceInstanceSchemaInvalid(t *testing.T) {
 			pluginConfigMapWithDeps: configMapWithDependenciesPlugin(false, false),
 		},
 		test: func(t *testing.T, ctx context.Context, cntrlr *bundlec.Controller, tc *testCase) {
-			retriable, err := cntrlr.ProcessBundle(tc.logger, tc.bundle)
-			assert.False(t, retriable)
+			external, retriable, err := cntrlr.ProcessBundle(tc.logger, tc.bundle)
 			assert.EqualError(t, err, `error processing resource(s): ["`+resSi1+`" "`+resSi2+`"]`)
+			assert.True(t, external, "error should be an external error") // bunch of spec validation errors
+			assert.False(t, retriable, "error should not be a retriable error")
 
 			actions := tc.smithFake.Actions()
 			require.Len(t, actions, 3)

--- a/pkg/controller/bundlec_test/two_resources_same_name_test.go
+++ b/pkg/controller/bundlec_test/two_resources_same_name_test.go
@@ -54,9 +54,10 @@ func TestTwoResourcesWithSameName(t *testing.T) {
 			pluginConfigMapWithDeps: configMapWithDependenciesPlugin(false, false),
 		},
 		test: func(t *testing.T, ctx context.Context, cntrlr *bundlec.Controller, tc *testCase) {
-			retriable, err := cntrlr.ProcessBundle(tc.logger, tc.bundle)
+			external, retriable, err := cntrlr.ProcessBundle(tc.logger, tc.bundle)
 			assert.EqualError(t, err, `bundle contains two resources with the same name "`+resP1+`"`)
-			assert.False(t, retriable)
+			assert.True(t, external, "error should be an external error") // resources with same name
+			assert.False(t, retriable, "error should not be a retriable error")
 
 			actions := tc.smithFake.Actions()
 			require.Len(t, actions, 3)

--- a/pkg/controller/bundlec_test/zz_plumbing_for_test.go
+++ b/pkg/controller/bundlec_test/zz_plumbing_for_test.go
@@ -313,8 +313,10 @@ func (tc *testCase) run(t *testing.T) {
 
 func (tc *testCase) defaultTest(t *testing.T, ctx context.Context, cntrlr *bundlec.Controller) {
 	require.NotNil(t, tc.bundle)
-	_, err := cntrlr.ProcessBundle(tc.logger, tc.bundle)
+	external, retriable, err := cntrlr.ProcessBundle(tc.logger, tc.bundle)
 	require.NoError(t, err)
+	assert.False(t, external)
+	assert.False(t, retriable)
 }
 
 func (tc *testCase) verifyActions(t *testing.T) {


### PR DESCRIPTION
This changes Smith to:

1. Make handleProcessResult() less confusing - the error now represents the error of the actual status update rather than having this weird error combining
2. Error combining takes place outside of handleProcessResult() and now deals with a few more external error cases
3. Update ctrl library